### PR TITLE
Update ByteUtil.java

### DIFF
--- a/abs-foreign-interface/java/abs-java-util/src/main/java/abs/fli/java/io/ByteUtil.java
+++ b/abs-foreign-interface/java/abs-java-util/src/main/java/abs/fli/java/io/ByteUtil.java
@@ -50,7 +50,7 @@ public class ByteUtil {
     }
     
     public List<Byte> convert(byte[] bytes) {
-        java.util.List<java.lang.Byte> java = new ArrayList<java.lang.Byte>();
+        java.util.List<java.lang.Byte> java = new ArrayList<java.lang.Byte>(bytes.length);
         for (byte b : bytes) {
             java.add(java.lang.Byte.valueOf(b));
         }


### PR DESCRIPTION
Avoid unnecessary new array allocation and copying by making the initial capacity explicit.