### PR TITLE
Add a line to README for proper project import

### DIFF
--- a/eclipse-plugin/README.build
+++ b/eclipse-plugin/README.build
@@ -26,6 +26,7 @@ Import the source code of the plug-in into Eclipse:
 1c. Select only the following two projects (de-select the others), and click Finish:
    org.abs-models.abs.compiler
    org.abs-models.abs.plugin
+   org.abs-models.sdedit
 
 Build and run the plug-in
 2a. In the Package Eclorer: left click the org.abs-models.abs.plugin project


### PR DESCRIPTION
Add that `org.abs-models.sdedit` should also be imported
for plugin development.

Rel #4