### PR TITLE
Non-unique accessor functions

### DIFF
--- a/abs-docs/asciidoc/types.adoc
+++ b/abs-docs/asciidoc/types.adoc
@@ -117,9 +117,9 @@ valid identifier.  If a name is given, it defines a function that, when passed a
 value expressed with the given constructor, return the argument.
 
 The name of an accessor function must be unique in the module it is
-defined in.  It is an error to have multiple accessor functions with the same
-name, or to have a function definition with the same name as an accessor
-function.
+defined in.  It is an error to have a function definition with the same name as an accessor
+function or to have multiple accessor functions with the same name, unless they
+belong to the same data type.
 
 .Example
 [source]

--- a/frontend/src/abs/backend/prettyprint/PrettyPrinter.jadd
+++ b/frontend/src/abs/backend/prettyprint/PrettyPrinter.jadd
@@ -525,7 +525,7 @@ aspect doPrettyPrinter {
         stream.print(";");
     }
     
-    private boolean FunctionDecl.isSelector() {
+    protected boolean FunctionDecl.isSelector() {
     	for (Annotation a : getAnnotationList()) {
             if (! (a.getValue() instanceof StringLiteral)) {
                 continue;

--- a/frontend/src/abs/frontend/analyser/ErrorMessage.java
+++ b/frontend/src/abs/frontend/analyser/ErrorMessage.java
@@ -5,6 +5,7 @@
 package abs.frontend.analyser;
 
 public enum ErrorMessage {
+    ACESSOR_INCOMPARABLE_TYPE("Accessor functions with incomparable types, %s and %s."),
     CYCLIC_INHERITANCE("Cyclic inheritance chain for interface: %s."),
     UNKOWN_INTERFACE("Unknown interface: %s."),
     UNKOWN_DATATYPE("Unknown datatype: %s."),

--- a/frontend/src/abs/frontend/delta/DeltaModifierApplicator.jadd
+++ b/frontend/src/abs/frontend/delta/DeltaModifierApplicator.jadd
@@ -224,14 +224,9 @@ aspect DeltaModifierApplicator {
         DataTypeDecl dtd = this.getDataTypeDecl().treeCopyNoTransform();
         dtd.setFileName(getDataTypeDecl().getFileName());
         module.getDecls().addChild(dtd);
-        for (DataConstructor c : dtd.getDataConstructors()) {
-            int i = 0;
-            for (ConstructorArg ca : c.getConstructorArgs()) {
-                if (ca.hasSelectorName()) {
-                    module.getDecls().addChild(new ASTPreProcessor().createSelectorFunctionForDeltaApplication(dtd, c, ca, i));
-                }
-                i++;
-            }
+
+        for (FunctionDecl fd : new ASTPreProcessor().createSelectorFunctionsForDeltaApplication(dtd)) {
+            module.getDecls().addChild(fd);
         }
     }
 

--- a/frontend/src/abs/frontend/typechecker/TypeChecker.jadd
+++ b/frontend/src/abs/frontend/typechecker/TypeChecker.jadd
@@ -329,6 +329,10 @@ aspect TypeChecker {
     }
 
     public void ParametricFunctionDecl.typeCheck(SemanticConditionList e) {
+        // Selectors are generated, and assumed to be type correct.
+        if (isSelector()) {
+            return;
+        }
         super.typeCheck(e);
         HashSet<String> names = new HashSet<String>();
         for (TypeParameterDecl d : getTypeParameters()) {
@@ -397,10 +401,25 @@ aspect TypeChecker {
 
     public void DataTypeDecl.typeCheck(SemanticConditionList e) {
         HashSet<String> names = new HashSet<String>();
+        HashMap<String, Type> argumentType = new HashMap<String, Type>();
         for (DataConstructor c : getDataConstructors()) {
             c.typeCheck(e);
             if (!names.add(c.getName())) {
                 e.add(new TypeError(c, ErrorMessage.DUPLICATE_CONSTRUCTOR, c.getName()));
+            }
+            // Record the type associated with each selector name, and ensure
+            // it is the same for every selector with the same name
+            for (ConstructorArg ca : c.getConstructorArgs()) {
+                if (!ca.hasSelectorName())
+                    continue;
+                String argName = ca.getSelectorName().getName();
+                Type t1 = ca.getType();
+                Type t2 = argumentType.get(argName);
+                if (t2 != null && !t1.equals(t2)) {
+                    e.add(new TypeError(ca, ErrorMessage.ACESSOR_INCOMPARABLE_TYPE, t1, t2));
+                } else {
+                    argumentType.put(argName, t1);
+                }
             }
         }
     }


### PR DESCRIPTION
These commits enables data constructors of the same abstract data type to have the same accessor name. An example could be a data type `Person` where one always stores a name, but does not necessarily store the age; here it would be convenient to use the accessor function `name` regardless of whether the age is provided or not.

Currently, one would have to find some workaround to avoid name clashes, e.g.:

```haskell
data Person = Person(String name1) | Person(String name2, Int age)
```

With these commits, the following is allowed:

```haskell
data Person = Person(String name) | Person(String name, Int age)
```