### PR TITLE
Add ecj jar to eclipse classpath

### DIFF
--- a/frontend/.classpath
+++ b/frontend/.classpath
@@ -33,5 +33,6 @@
 	<classpathentry kind="lib" path="lib/org.sat4j.core.jar"/>
 	<classpathentry kind="lib" path="lib/antlr-4.6-complete.jar"/>
 	<classpathentry kind="lib" path="lib/findbugs-ant-1.3.9.jar"/>
+	<classpathentry kind="lib" path="lib/ecj-4.6.2.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
The <code>ecj-4.6.2.jar</code> was present in the ant classpath, but not in the eclipse classpath, which led to compilation errors for the Java backend if an IDE was used.