### PR TITLE
Fix erlang backend under windows

### DIFF
--- a/frontend/src/abs/backend/erlang/ErlangBackend.java
+++ b/frontend/src/abs/backend/erlang/ErlangBackend.java
@@ -19,6 +19,7 @@ import abs.backend.common.InternalBackendException;
 import abs.common.NotImplementedYetException;
 import abs.frontend.ast.Model;
 import abs.frontend.parser.Main;
+import org.apache.commons.io.output.NullOutputStream;
 
 /**
  * Translates given ABS Files to an Erlang program
@@ -136,6 +137,7 @@ public class ErlangBackend extends Main {
 	String[] rebarProgram = new String[] {"escript", "../bin/rebar", "compile"};
         Process p = Runtime.getRuntime().exec(rebarProgram, null, new File(destDir, "absmodel"));
         if (options.contains(CompileOptions.VERBOSE)) IOUtils.copy(p.getInputStream(), System.out);
+        else IOUtils.copy(p.getInputStream(), new NullOutputStream());
         p.waitFor();
         if (p.exitValue() != 0) {
             String message = "Compilation of generated erlang code failed with exit value " + p.exitValue();

--- a/frontend/src/abs/backend/erlang/ErlangBackend.java
+++ b/frontend/src/abs/backend/erlang/ErlangBackend.java
@@ -101,9 +101,28 @@ public class ErlangBackend extends Main {
         compile(model, destDir, compileOptions);
     }
 
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
+    private static String getEscapedDoubleQuote() {
+        if(isWindows()) {
+            // "" will be resolved to "
+            return "\"\"";
+        } else {
+            // " just works
+            return "\"";
+        }
+    }
+
     public static void compile(Model m, File destDir, EnumSet<CompileOptions> options) throws IOException, InterruptedException, InternalBackendException {
         // check erlang version number
-        Process versionCheck = Runtime.getRuntime().exec(new String[] { "erl", "-eval", "io:fwrite(\"~s\n\", [erlang:system_info(otp_release)]), halt().", "-noshell" });
+        String erlVersionCheckCode = "io:fwrite("
+            + getEscapedDoubleQuote()
+            + "~s\n"
+            + getEscapedDoubleQuote()
+            + ", [erlang:system_info(otp_release)]), halt().";
+        Process versionCheck = Runtime.getRuntime().exec(new String[] { "erl", "-eval", erlVersionCheckCode, "-noshell" });
         versionCheck.waitFor();
         BufferedReader ir = new BufferedReader(new InputStreamReader(versionCheck.getInputStream()));
         int version = Integer.parseInt(ir.readLine());


### PR DESCRIPTION
Compiling with the Erlang backend under Windows was not possible, because the quotes in the Erlang version check code were not properly escaped. Unfortunately, I did not find a way to escape the quotes that works in both Windows and Linux, so the OS name is checked now to find the right way.

Furthermore, the <code>escript</code> process output is now written to a <code>NullOutputStream</code>, because the process occasionally froze due to its output buffer being full.

This has been tested with Windows 10 and Ubuntu 14.04.