### PR TITLE
Use Java 8 Streams in TreeUtils

### DIFF
--- a/frontend/src/abs/common/TreeUtils.jadd
+++ b/frontend/src/abs/common/TreeUtils.jadd
@@ -1,3 +1,9 @@
+import abs.common.TreeUtilsHelper;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 aspect TreeUtils {
 
     /**
@@ -24,8 +30,8 @@ aspect TreeUtils {
      * @return an unmodifiable list of nodes, never null
      * @throws NullPointerException if <code>type</code> is null
      */
-    public <N extends ASTNode<?>> java.util.List<N> ASTNode.findChildren(Class<N> type) {
-        return findChildren(type, false);
+    public <N> java.util.List<N> ASTNode.findChildren(Class<N> type) {
+        return TreeUtilsHelper.findChildren(this, type);
     }
 
     /**
@@ -37,29 +43,33 @@ aspect TreeUtils {
      * @return an unmodifiable list of nodes, never null
      * @throws NullPointerException if <code>type</code> is null
      */
-    public <N extends ASTNode<?>> java.util.List<N> ASTNode.findChildren(Class<N> type, boolean lazy) {
-        java.util.List<N> result = new LinkedList<>();
-        findChildren(result, this, Objects.requireNonNull(type), lazy);
-        return Collections.unmodifiableList(result);
+    public <N> java.util.List<N> ASTNode.findChildren(Class<N> type, boolean lazy) {
+        return TreeUtilsHelper.findChildren(this, type, lazy);
     }
 
-    private <N extends ASTNode<?>> void ASTNode.findChildren(
-        java.util.List<N> list,
-        ASTNode<?> node,
-        Class<N> type,
-        boolean lazy) {
-        if (node != null) {
-            if (type.isInstance(node)) {
-                list.add(type.cast(node));
-                if (lazy) {
-                    return;
-                }
-            }
-
-            for (int index = 0; index < node.getNumChildNoTransform(); ++index) {
-                findChildren(list, node.getChildNoTransform(index), type, lazy);
-            }
-        }
+    /**
+     * Lazily finds children of this node which can be casted by the cast function.
+     * This node will also be included if applicable.
+     *
+     * <p>The cast function receives an ASTNode and tries to cast it to the desired return type.
+     * If the node can't be casted, it returns null.
+     * See the convenience functions {@link TreeUtilsHelper#cast(Class)} and {@link TreeUtilsHelper#recurse(java.util.List)}.
+     * </p>
+     *
+     * <p>The recurse predicate receives a node casted by the cast function and decides
+     * whether to recurse over the nodes children.
+     * See the convenience function {@link TreeUtilsHelper#recurse(java.util.List)}.
+     * </p>
+     *
+     * @param cast a function receiving an ASTNode and casts to N, or returns null
+     * @param recurse if the cast function could cast a node, this predicate decides whether to recurse over the casted node's children
+     * @param <N> the type of nodes in the returned stream
+     * @return a stream of nodes
+     */
+    public <N> Stream<N> ASTNode.findChildren(
+            Function<? super ASTNode<?>, N> cast,
+            Predicate<? super N> recurse) {
+        return TreeUtilsHelper.findChildren(this, cast, recurse);
     }
 
     /**

--- a/frontend/src/abs/common/TreeUtilsHelper.java
+++ b/frontend/src/abs/common/TreeUtilsHelper.java
@@ -1,0 +1,127 @@
+package abs.common;
+
+import abs.frontend.ast.ASTNode;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public final class TreeUtilsHelper {
+
+	private TreeUtilsHelper() {
+
+	}
+
+	/**
+	 * Finds all children of this node with the specified <code>type</code>. If this node has the
+	 * specified type, it will be included in the result.
+	 *
+	 * @param type the type to search for
+	 * @return an unmodifiable list of nodes, never null
+	 * @throws NullPointerException if <code>type</code> is null
+	 */
+	public static <N> java.util.List<N> findChildren(ASTNode<?> node, Class<N> type) {
+		return findChildren(node, type, false);
+	}
+
+	/**
+	 * Finds all children of this node with the specified <code>type</code>. If this node has the
+	 * specified type, it will be included in the result.
+	 *
+	 * @param type the type to search for
+	 * @param lazy if true, children of found N nodes will not be included
+	 * @return an unmodifiable list of nodes, never null
+	 * @throws NullPointerException if <code>type</code> is null
+	 */
+	public static <N> java.util.List<N> findChildren(ASTNode<?> node, Class<N> type, boolean lazy) {
+		return findChildren(node, cast(type), n -> !lazy).collect(Collectors.toList());
+	}
+
+	/**
+	 * Creates a Function which casts ASTNode instances of the given type, or returns null for incompatible nodes.
+	 *
+	 * @param type the desired type
+	 * @param <N> the returned type
+	 * @return a cast function
+	 */
+	public static <N> Function<Object, N> cast(Class<N> type) {
+		Objects.requireNonNull(type);
+		return node -> type.isInstance(node) ? type.cast(node) : null;
+	}
+
+	/**
+	 * Creates a function which casts an ASTNode to any of the given types, or returns null if none match.
+	 *
+	 * @param types a list of types
+	 * @param <N> a common supertype of all given types
+	 * @return a cast function
+	 */
+	public static <N> Function<Object, N> cast(List<Class<? extends N>> types) {
+		Objects.requireNonNull(types);
+		return node -> types.stream()
+				.filter(t -> t.isInstance(node))
+				.findAny()
+				.map(t -> t.cast(node))
+				.orElse(null);
+	}
+
+	/**
+	 * Creates a predicate that matches any of the given types
+	 *
+	 * @param recurseTypes a list of types
+	 * @param <N> a common supertype of the given types
+	 * @return a predicate matching nodes of any of the given types
+	 */
+	public static <N> Predicate<N> recurse(List<Class<? extends N>> recurseTypes) {
+		return node -> recurseTypes.stream().anyMatch(type -> type.isInstance(node));
+	}
+
+	/**
+	 * Lazily finds children of this node which can be casted by the cast function.
+	 * The root node will also be visited.
+	 *
+	 * <p>The cast function receives an ASTNode and tries to cast it to the desired return type.
+	 * If the node can't be casted, it returns null.
+	 * See the convenience functions {@link #cast(Class)} and {@link #cast(List)}.
+	 * </p>
+	 *
+	 * <p>The recurse predicate receives a node casted by the cast function and decides
+	 * whether to recurse over the nodes children.
+	 * See the convenience function {@link #recurse(List)}.
+	 * </p>
+	 *
+	 * @param node the root node for the search
+	 * @param cast a function receiving an ASTNode and casts to N, or returns null
+	 * @param recurse if the cast function could cast a node, this predicate decides whether to recurse over the casted node's children
+	 * @param <N> the type of nodes in the returned stream
+	 * @return a stream of nodes
+	 */
+	public static <N> Stream<N> findChildren(
+			ASTNode<?> node,
+			Function<? super ASTNode<?>, N> cast,
+			Predicate<? super N> recurse) {
+		if (node != null) {
+			N casted = cast.apply(node);
+			Stream<N> current = null;
+			if (casted != null) {
+				current = Stream.of(casted);
+				if (!recurse.test(casted)) {
+					return current;
+				}
+			}
+
+			Stream<N> children = IntStream.range(0, node.getNumChildNoTransform())
+					.mapToObj(node::getChildNoTransform)
+					.flatMap(n -> findChildren(n, cast, recurse));
+			if (current == null) {
+				return children;
+			} else {
+				return Stream.concat(current, children);
+			}
+		}
+		return Stream.empty();
+	}
+}

--- a/frontend/tests/abs/AllTests.java
+++ b/frontend/tests/abs/AllTests.java
@@ -1,5 +1,5 @@
-/** 
- * Copyright (c) 2009-2011, The HATS Consortium. All rights reserved. 
+/**
+ * Copyright (c) 2009-2011, The HATS Consortium. All rights reserved.
  * This file is licensed under the terms of the Modified BSD License.
  */
 package abs;
@@ -10,5 +10,6 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     abs.frontend.AllFrontendTests.class
-    , abs.backend.AllBackendTests.class })
+    , abs.backend.AllBackendTests.class
+	, abs.common.AllCommonTests.class })
 public class AllTests {}

--- a/frontend/tests/abs/common/AllCommonTests.java
+++ b/frontend/tests/abs/common/AllCommonTests.java
@@ -1,0 +1,12 @@
+package abs.common;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+		TreeUtilsTest.class
+})
+public class AllCommonTests {
+
+}

--- a/frontend/tests/abs/common/TreeUtilsTest.java
+++ b/frontend/tests/abs/common/TreeUtilsTest.java
@@ -1,0 +1,188 @@
+package abs.common;
+
+import static abs.common.TreeUtilsHelper.cast;
+import static abs.common.TreeUtilsHelper.recurse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import abs.frontend.FrontendTest;
+import abs.frontend.ast.ASTNode;
+import abs.frontend.ast.AddExp;
+import abs.frontend.ast.Decl;
+import abs.frontend.ast.ExpFunctionDef;
+import abs.frontend.ast.FnApp;
+import abs.frontend.ast.FunctionDecl;
+import abs.frontend.ast.FunctionDef;
+import abs.frontend.ast.IntLiteral;
+import abs.frontend.ast.Model;
+import abs.frontend.ast.PureExp;
+import abs.frontend.ast.Stmt;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+public class TreeUtilsTest extends FrontendTest {
+
+	@Test
+	public void closestParent() {
+		Model model = assertParseOkStdLib("def Int test() = 1;");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		PureExp exp = ((ExpFunctionDef) functionDecl.getFunctionDef()).getRhs();
+
+		assertSame(functionDecl, exp.closestParent(Decl.class));
+		assertSame(functionDecl, exp.closestParent(FunctionDecl.class));
+	}
+
+	@Test
+	public void closestParentIgnoresSelf() {
+		Model model = assertParseOkStdLib("def Int test() = 1;");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		FunctionDef functionDef = functionDecl.getFunctionDef();
+		assertSame(functionDecl, functionDef.closestParent(ASTNode.class));
+	}
+
+	@Test
+	public void closestParentNotFound() {
+		Model model = assertParseOkStdLib("def Int test() = 1;");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertNull(functionDecl.closestParent(FunctionDecl.class));
+	}
+
+	@Test
+	public void findChildrenList() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+
+		List<PureExp> children = functionDecl.getFunctionDef().findChildren(PureExp.class);
+		assertEquals(2, children.size());
+	}
+
+	@Test
+	public void findChildrenListLazy() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+
+		List<PureExp> children = functionDecl.getFunctionDef().findChildren(PureExp.class, true);
+		assertEquals(1, children.size());
+		assertTrue(children.get(0) instanceof FnApp);
+	}
+
+	@Test
+	public void findChildrenListNotNull() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+
+		List<Stmt> children = functionDecl.getFunctionDef().findChildren(Stmt.class);
+		assertNotNull(children);
+		assertTrue(children.isEmpty());
+	}
+
+	@Test
+	public void castCorrect() {
+		String s = "";
+		Integer i = 1;
+
+		Function<Object, String> stringCast = cast(String.class);
+		assertNull(stringCast.apply(i));
+		assertSame(s, stringCast.apply(s));
+	}
+
+	@Test
+	public void multiCastCorrect() {
+		String s = "";
+		Integer i = 1;
+		Double d = 0.0;
+
+		Function<Object, Number> numberCast = cast(ImmutableList.of(Integer.class, Double.class));
+		assertNull(numberCast.apply(s));
+		assertSame(i, numberCast.apply(i));
+		assertSame(d, numberCast.apply(d));
+	}
+
+	@Test
+	public void recurseCorrect() {
+		Integer i = 1;
+		Double d = 0.0;
+
+		Predicate<Number> numberPredicate = recurse(ImmutableList.of(Double.class));
+		assertTrue(numberPredicate.test(d));
+		assertFalse(numberPredicate.test(i));
+	}
+
+	@Test
+	public void findChildrenMultipleTypes() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		FunctionDef def = functionDecl.getFunctionDef();
+
+		Stream<PureExp> children = def.findChildren(cast(ImmutableList.of(FnApp.class, IntLiteral.class)), n -> true);
+		assertNotNull(children);
+		List<PureExp> result = children.distinct().collect(Collectors.toList());
+		assertEquals(2, result.size());
+		for (PureExp exp : result) {
+			assertTrue(exp instanceof FnApp || exp instanceof IntLiteral);
+		}
+	}
+
+	@Test
+	public void recurseForSome() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = 1 + test(2);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		FunctionDef def = functionDecl.getFunctionDef();
+
+		Stream<PureExp> children = def.findChildren(cast(PureExp.class), AddExp.class::isInstance);
+		assertNotNull(children);
+		List<PureExp> result = children.distinct().collect(Collectors.toList());
+
+		// expecting AddExp, IntLiteral(1), FnApp, NOT IntLiteral(2)
+		assertEquals(3, result.size());
+		for (PureExp exp : result) {
+			assertFalse(exp instanceof IntLiteral && ((IntLiteral) exp).getContent().equals("2"));
+		}
+	}
+
+	@Test
+	public void findChildrenIncludeSelf() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		ExpFunctionDef def = (ExpFunctionDef) functionDecl.getFunctionDef();
+		PureExp exp = def.getRhs();
+
+		Stream<PureExp> children = def.findChildren(cast(PureExp.class), n -> true);
+		assertNotNull(children);
+		List<PureExp> result = children.distinct().collect(Collectors.toList());
+		assertEquals(2, result.size());
+		assertTrue(result.contains(exp));
+	}
+
+	@Test
+	public void findChildrenIncludeOnlySelf() {
+		Model model = assertParseOkStdLib("def Int test(Int i) = test(1);");
+		FunctionDecl functionDecl = getLastFunctionDecl(model);
+		assertEquals("test", functionDecl.getName());
+		ExpFunctionDef def = (ExpFunctionDef) functionDecl.getFunctionDef();
+		PureExp exp = def.getRhs();
+
+		Stream<PureExp> children = def.findChildren(cast(PureExp.class), n -> false);
+		assertNotNull(children);
+		List<PureExp> result = children.distinct().collect(Collectors.toList());
+		assertEquals(1, result.size());
+		assertTrue(result.contains(exp));
+	}
+}


### PR DESCRIPTION
Backwards-compatible and now with some tests.

Unfortunately JastAdd doesn't recognize the lambda syntax in .jadd and .jrag files yet, but this change will still be useful in regular Java files.