### PR TITLE
Fix backend tests on Windows

### DIFF
--- a/frontend/src/abs/backend/erlang/ErlangBackend.java
+++ b/frontend/src/abs/backend/erlang/ErlangBackend.java
@@ -3,6 +3,7 @@
  */
 package abs.backend.erlang;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -132,7 +133,8 @@ public class ErlangBackend extends Main {
         return 0;
     }
 
-    private static boolean isWindows() {
+    @VisibleForTesting
+    static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
 

--- a/frontend/src/abs/backend/java/JavaBackend.java
+++ b/frontend/src/abs/backend/java/JavaBackend.java
@@ -7,6 +7,9 @@ package abs.backend.java;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.*;
 import java.util.List;
 
@@ -23,7 +26,11 @@ import abs.frontend.typechecker.*;
 
 public class JavaBackend extends Main {
 
-    public final static String CHARSET = "UTF-8";
+    /**
+     * The charset to use for generated files. This will also be one of the {@link StandardCharsets}, so using it
+     * is guaranteed not to throw an {@link UnsupportedCharsetException}.
+     */
+    public final static Charset CHARSET = StandardCharsets.UTF_8;
 
     public static void main(final String... args) {
         doMain(args);

--- a/frontend/src/abs/backend/java/codegeneration/GenerateJava.jadd
+++ b/frontend/src/abs/backend/java/codegeneration/GenerateJava.jadd
@@ -53,7 +53,7 @@ aspect GenerateJava {
             File file = generatedJavaPackage.createJavaFile(mainName);
             PrintStream stream = null;
             try {
-                stream = new JavaCodeStream(file);
+                stream = JavaCodeStream.from(file);
                 stream.println("package " + generatedJavaPackage.packageName + ";");
                 //stream.println(JavaBackendConstants.LIB_IMPORT_STATEMENT);
 
@@ -87,7 +87,7 @@ aspect GenerateJava {
         try {
             String name = JavaBackend.getJavaName(this);
             File file = pkg.createJavaFile(name);
-            s = new JavaCodeStream(file);
+            s = JavaCodeStream.from(file);
             s.println("package " + pkg.packageName + ";");
             //s.println(JavaBackendConstants.LIB_IMPORT_STATEMENT);
             generateJava(s);
@@ -599,7 +599,8 @@ aspect GenerateJava {
                 // KLUDGE: leave this in until we can generate ABS `throw'
                 // statements
                 stream.print("throw new " + UnmatchedCaseException.class.getName() + "(\"");
-                stream.println(getPositionString() + " value \" + " + varName + " + \" did not match any pattern.\");");
+                JavaGeneratorHelper.printEscapedString(stream, getPositionString());
+                stream.println(" value \" + " + varName + " + \" did not match any pattern.\");");
             } else {
                 // Found a match => exit the statement
                 stream.println("continue;");
@@ -615,7 +616,8 @@ aspect GenerateJava {
         stream.print("if (!");
         getCondition().generateJava(stream);
         stream.print(".toBoolean()) throw new " + ABSAssertException.class.getName() + "(\"");
-        stream.println(getPositionString() + " Assertion failed\");");
+        JavaGeneratorHelper.printEscapedString(stream, getPositionString());
+        stream.println(" Assertion failed\");");
 
     }
 
@@ -843,7 +845,8 @@ aspect GenerateJava {
             i++;
         }
         stream.print("throw new " + UnmatchedCaseException.class.getName() + "(\"");
-        stream.println(getPositionString() + " value \" + __ABS_value + \" did not match any pattern.\");");
+        JavaGeneratorHelper.printEscapedString(stream, getPositionString());
+        stream.println(" value \" + __ABS_value + \" did not match any pattern.\");");
         stream.println("}");
         stream.print("}.of(");
         for (String freeVarName : getFreeVars()) {

--- a/frontend/src/abs/backend/java/codegeneration/JavaCodeStream.java
+++ b/frontend/src/abs/backend/java/codegeneration/JavaCodeStream.java
@@ -4,8 +4,10 @@
  */
 package abs.backend.java.codegeneration;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
@@ -15,18 +17,33 @@ import com.google.common.base.Strings;
 import abs.backend.java.JavaBackend;
 
 public class JavaCodeStream extends PrintStream {
+
+    private static final String LINE_SEPARATOR_PROPERTY = "line.separator";
     private static final int INDENT_LENGTH = 4;
     private static final String INDENT1 = Strings.repeat(" ", INDENT_LENGTH);
 
     private Boolean startNewLine = true;
     private String indent = "";
 
-    public JavaCodeStream(OutputStream out) throws UnsupportedEncodingException {
-        super(out, false, JavaBackend.CHARSET);
+    private JavaCodeStream(OutputStream out) throws UnsupportedEncodingException {
+        super(out, false, JavaBackend.CHARSET.name());
     }
 
-    public JavaCodeStream(File file) throws FileNotFoundException, UnsupportedEncodingException {
-        super(file, JavaBackend.CHARSET);
+    public static JavaCodeStream from(OutputStream out) {
+        // Set the line separator to LF while the PrintStream is created so it will print LF on println() calls.
+        System.setProperty(LINE_SEPARATOR_PROPERTY, "\n");
+        try {
+            return new JavaCodeStream(out);
+        } catch (UnsupportedEncodingException e) {
+            // the used charset must be supported by all Java runtime implementations
+            throw new IllegalStateException(e);
+        } finally {
+            System.setProperty(LINE_SEPARATOR_PROPERTY, System.lineSeparator());
+        }
+    }
+
+    public static JavaCodeStream from(File file) throws FileNotFoundException {
+        return from(new BufferedOutputStream(new FileOutputStream(file)));
     }
 
     public void incIndent() {

--- a/frontend/src/abs/backend/java/codegeneration/JavaCompiler.java
+++ b/frontend/src/abs/backend/java/codegeneration/JavaCompiler.java
@@ -1,5 +1,5 @@
-/** 
- * Copyright (c) 2009-2011, The HATS Consortium. All rights reserved. 
+/**
+ * Copyright (c) 2009-2011, The HATS Consortium. All rights reserved.
  * This file is licensed under the terms of the Modified BSD License.
  */
 package abs.backend.java.codegeneration;
@@ -12,7 +12,7 @@ import org.eclipse.jdt.core.compiler.batch.BatchCompiler;
 import abs.backend.java.JavaBackend;
 
 class JavaCompiler {
-    private static final String DEFAULT_PREFIX = "-encoding " + JavaBackend.CHARSET+" -source 5 -nowarn -noExit ";
+    private static final String DEFAULT_PREFIX = "-encoding " + JavaBackend.CHARSET.name() +" -source 5 -nowarn -noExit ";
 
     public static void main(String... args) throws JavaCodeGenerationException {
         if (!compile(args))
@@ -26,7 +26,7 @@ class JavaCompiler {
         }
         return compile(sb.toString());
     }
-    
+
     public static boolean compile(String args) throws JavaCodeGenerationException {
         StringWriter outWriter = new StringWriter();
         StringWriter errWriter = new StringWriter();

--- a/frontend/src/abs/backend/java/codegeneration/JavaGeneratorHelper.java
+++ b/frontend/src/abs/backend/java/codegeneration/JavaGeneratorHelper.java
@@ -555,12 +555,18 @@ public class JavaGeneratorHelper {
 
     public static String generateUserSchedulingStrategy(NewExp exp, PureExp scheduler) {
         String className = "UserSchedulingStrategy_" + JavaBackend.getRandomName();
-        PrintStream stream = null;
+        JavaCode.Package pkg;
+        File file;
         try {
-            JavaCode.Package pkg = exp.getModuleDecl().getJavaPackage();
-            File file = pkg.createJavaFile(className);
-            stream = new JavaCodeStream(file);
+            pkg = exp.getModuleDecl().getJavaPackage();
+            file = pkg.createJavaFile(className);
+        } catch (JavaCodeGenerationException | IOException e) {
+            // TODO properly handle exceptions
+            e.printStackTrace();
+            return null;
+        }
 
+        try (PrintStream stream = JavaCodeStream.from(file)){
             stream.println("package " + pkg.packageName + ";");
             stream.print("public final class " + className);
             stream.println(" extends " + UserSchedulingStrategy.class.getName() + " {");
@@ -580,16 +586,9 @@ public class JavaGeneratorHelper {
 
             // connect generated TaskSchedulingStrategy to the cog's TaskScheduler
             return pkg.packageName + "." + className;
-
-        } catch (JavaCodeGenerationException e) {
-            // TODO properly handle exception
-            e.printStackTrace();
         } catch (IOException e) {
             // TODO properly handle exception
             e.printStackTrace();
-        } finally {
-            if (stream != null)
-                stream.close();
         }
         return null;
     }

--- a/frontend/src/abs/backend/java/codegeneration/dynamic/GenerateJava.jadd
+++ b/frontend/src/abs/backend/java/codegeneration/dynamic/GenerateJava.jadd
@@ -82,7 +82,7 @@ aspect GenerateJavaDynamic_Core {
             File file = p.createJavaFile(mainName);
             PrintStream stream = null;
             try {
-                stream = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+                stream = JavaCodeStream.from(file);
                 stream.println("package " + p.packageName + ";");
 
                 stream.println("public class " + mainName + " extends " + ABSDynamicObject.class.getName() + " {");
@@ -123,7 +123,7 @@ aspect GenerateJavaDynamic_Core {
         try {
             String name = JavaBackend.getJavaName(this);
             File file = pkg.createJavaFile(name);
-            s = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+            s = JavaCodeStream.from(file);
             s.println("package " + pkg.packageName + ";");
             generateJavaDynamic(s);
         } finally {
@@ -527,8 +527,8 @@ aspect GenerateJavaDynamic_Core {
         stream.print("if (!");
         getCondition().generateJavaDynamic(stream);
         stream.print(".toBoolean()) throw new " + ABSAssertException.class.getName() + "(\"");
-        stream.println(getPositionString() + " Assertion failed\");");
-
+        DynamicJavaGeneratorHelper.printEscapedString(stream, getPositionString());
+        stream.println(" Assertion failed\");");
     }
 
     /*
@@ -712,7 +712,8 @@ aspect GenerateJavaDynamic_Core {
             i++;
         }
         stream.print("throw new " + UnmatchedCaseException.class.getName() + "(\"");
-        stream.println(getPositionString() + " value \" + __ABS_value + \" did not match any pattern.\");");
+        DynamicJavaGeneratorHelper.printEscapedString(stream, getPositionString());
+        stream.println(" value \" + __ABS_value + \" did not match any pattern.\");");
         stream.println("}");
         stream.print("}.of(");
         for (String freeVarName : getFreeVars()) {
@@ -1056,7 +1057,7 @@ aspect GenerateJavaDynamic_DeltaModelling {
         generatedJavaClassName = JavaBackend.getModifierName();
         try {
             File file = pkg.createJavaFile(generatedJavaClassName);
-            stream = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+            stream = JavaCodeStream.from(file);
             stream.println("package " + pkg.packageName + ";");
 
             // gen header
@@ -1142,7 +1143,7 @@ aspect GenerateJavaDynamic_DeltaModelling {
         
         try {
             File file = pkg.createJavaFile(generatedJavaClassName);
-            stream = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+            stream = JavaCodeStream.from(file);
             // gen header
             stream.println("package " + pkg.packageName + ";");
             stream.println("public class " + generatedJavaClassName + " {");
@@ -1165,7 +1166,7 @@ aspect GenerateJavaDynamic_DeltaModelling {
         
         try {
             File file = pkg.createJavaFile(generatedJavaClassName);
-            stream = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+            stream = JavaCodeStream.from(file);
             // gen header
             stream.println("package " + pkg.packageName + ";");
             stream.println("public class " + generatedJavaClassName + " {");
@@ -1188,7 +1189,7 @@ aspect GenerateJavaDynamic_DeltaModelling {
         
         try {
             File file = pkg.createJavaFile(generatedJavaClassName);
-            stream = new JavaCodeStream(new BufferedOutputStream(new FileOutputStream(file)));
+            stream = JavaCodeStream.from(file);
             // gen header
             stream.println("package " + pkg.packageName + ";");
             stream.println("public class " + generatedJavaClassName + " {");

--- a/frontend/tests/abs/backend/erlang/ErlangTestDriver.java
+++ b/frontend/tests/abs/backend/erlang/ErlangTestDriver.java
@@ -152,7 +152,8 @@ public class ErlangTestDriver extends ABSTest implements BackendTestDriver {
      */
     private String run(File workDir, String mainModule) throws Exception {
         String val = null;
-        File runFile = new File(workDir, "run");
+        String runFileName = ErlangBackend.isWindows() ? "run.bat" : "run";
+        File runFile = new File(workDir, runFileName);
         ProcessBuilder pb = new ProcessBuilder(runFile.getAbsolutePath(), mainModule);
         pb.directory(workDir);
         pb.redirectErrorStream(true);


### PR DESCRIPTION
This allows running backend tests on Windows. The main problem was the Java backend putting Windows paths (containing backslashes) in Java String literals.

Backend tests are extremely slow on Windows, but at least they don't completely fail anymore.