### PR TITLE
Generate source and javadoc artifacts

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -121,7 +121,6 @@ jar {
     from configurations.runtimeClasspath
         .findAll { it.name.endsWith('jar') }
         .collect { zipTree(it) }
-    destinationDir=file('dist')
     reproducibleFileOrder=true
 }
 
@@ -133,6 +132,21 @@ task plainJar(type: Copy, dependsOn: jar) {
 }
 clean {
     delete 'dist/'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
 }
 
 task copyScripts(type: Copy) {
@@ -163,6 +177,10 @@ spotbugs {
     ignoreFailures = true
     showProgress = true
     excludeFilter = file('config/findbugs/findbugs-jastadd-filter.xml')
+}
+
+javadoc {
+    failOnError = false
 }
 
 tasks.withType(com.github.spotbugs.SpotBugsTask) {


### PR DESCRIPTION
- Only copy the compiled jar to `dist/`, don't initially generate it there
- Generate `sources` and `javadoc` jars (additionally to the compiled jar) in the `build/libs` dir

The generated jars could be used for distribution to a central repository in the future. Right now, they can be helpful for "manually" depending on the frontend.