### PR TITLE
Build project in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,25 @@
-FROM frolvlad/alpine-oraclejdk8:slim
-MAINTAINER Rudolf Schlatte <rudi@ifi.uio.no>
+FROM erlang:21-alpine AS jdk-erlang
+RUN apk --update add openjdk8 bash && rm -rf /var/cache/apk/*
+
+FROM jdk-erlang AS builder
+COPY ./.git /appSrc/.git
+COPY ./frontend /appSrc/frontend
+WORKDIR /appSrc/frontend
+RUN chmod +x gradlew \
+    && ./gradlew build -x test -x check
 
 # A dockerfile for running the `absc' command-line compiler
 
 # To build the image:
-#     docker build -t absc .
+#     docker build -t absc -f Dockerfile ..
 # To compile an abs model `file.abs' in the current directory:
 #     docker run --rm -v "$PWD":/usr/src -w /usr/src absc -erlang file.abs
 # To get a command-line inside the container for the current directory
 # (e.g., to run a model via `gen/erl/run' inside the container):
 #     docker run -it --rm -v "$PWD":/usr/src -w /usr/src --entrypoint /bin/sh absc
-
-
-RUN apk --update add erlang && rm -rf /var/cache/apk/*
-COPY src/bash/absc /usr/local/bin/absc
-COPY dist/absfrontend.jar /usr/local/lib/absfrontend.jar
+FROM jdk-erlang
+LABEL maintainer="Rudolf Schlatte <rudi@ifi.uio.no>"
+COPY --from=builder /appSrc/frontend/bin/bash/absc /usr/local/bin/absc
+COPY --from=builder /appSrc/frontend/dist/absfrontend.jar /usr/local/lib/absfrontend.jar
 CMD ["-help"]
 ENTRYPOINT ["/usr/local/bin/absc"]


### PR DESCRIPTION
- Switch to [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to get the smallest possible final image
- Use official erlang image as base because OTP 21 is hard to come by with package managers
- `MAINTAINER` is deprecated, so it has been replaced by `LABEL`

The context has to be the project root, because the `.git` folder is needed for the build, so build the image with:

```bash
docker build -t absc -f Dockerfile ..
```