### PR TITLE
Find dependencies for run scripts programmatically. Fixes #242

### DIFF
--- a/frontend/src/main/resources/erlang/run
+++ b/frontend/src/main/resources/erlang/run
@@ -1,4 +1,23 @@
-#!/usr/bin/env escript
-%%! -pa absmodel/ebin -pa absmodel/deps/cowboy/ebin -pa absmodel/deps/cowlib/ebin -pa absmodel/deps/ranch/ebin -pa absmodel/deps/jsx/ebin -pa gen/erl/absmodel/ebin -pa gen/erl/absmodel/deps/cowboy/ebin -pa gen/erl/absmodel/deps/cowlib/ebin -pa gen/erl/absmodel/deps/ranch/ebin -pa gen/erl/absmodel/deps/jsx/ebin
-main(Arg)->runtime:run(Arg).
+#!/bin/bash
 
+script=`realpath "$0"`
+codepaths=$(find "`dirname "$script"`" -name "ebin" -type d -print0 \
+                 | xargs -0 printf '%s","' | sed 's/","$//g')
+
+tmpfile=`mktemp`
+
+(
+    echo "#!/usr/bin/env escript"
+    echo "main(Arg)->"
+    echo "code:add_paths([\"$codepaths\"]),"
+    echo "runtime:run(Arg)."
+) > $tmpfile
+
+cleanup () {
+    rm $tmpfile &> /dev/null
+    return $exit_code
+}
+
+trap cleanup EXIT
+escript $tmpfile $@
+exit_code=$?

--- a/frontend/src/main/resources/erlang/start_console
+++ b/frontend/src/main/resources/erlang/start_console
@@ -1,3 +1,11 @@
 #!/bin/bash
-erl -pa absmodel/ebin -pa absmodel/deps/cowboy/ebin -pa absmodel/deps/cowlib/ebin -pa absmodel/deps/ranch/ebin -pa absmodel/deps/jsx/ebin -pa gen/erl/absmodel/ebin -pa gen/erl/absmodel/deps/cowboy/ebin -pa gen/erl/absmodel/deps/cowlib/ebin -pa gen/erl/absmodel/deps/ranch/ebin -pa gen/erl/absmodel/deps/jsx/ebin \
-    -s runtime start -extra "$@"
+
+script=`realpath "$0"`
+codepaths=$(find "`dirname "$script"`" -name "ebin" -type d -print0 \
+                 | xargs -0 printf '%s","' | sed 's/","$//g')
+(
+    echo "code:add_paths([\"$codepaths\"])."
+    echo "make:all([load])."
+    echo "runtime:start(\"$@\")."
+    cat
+) | erl


### PR DESCRIPTION
Hi!

The commit changes the `run` and `start_console` scripts. Instead of including the dependencies via `-pa`, they are found and added programmatically, which fixes #242.

For the `start_console` script, the sources are compiled before running the model, which is useful in combination with `link_sources`. This is only done for `start_console` because it is more commonly used when working with the compiler.

Note that the `run` script generates a temporary `escript` that is executed and deleted when the model terminates or crashes. This is not the cleanest solution, and if someone has a better idea, I'm all for it.