### PR TITLE
Fix for tests, which do not terminate

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -179,10 +179,12 @@ test {
     ignoreFailures=true
     maxParallelForks=project.gradle.startParameter.maxWorkerCount
 
-    // Allow dynamic exclusion of tests (https://blog.jdriven.com/2017/10/run-one-or-exclude-one-test-with-gradle/)
-    // Usage: gradle test -PexcludeTests='**/ErlangModelApiTests*'
+    // Allow dynamic exclusion of tests (based on https://blog.jdriven.com/2017/10/run-one-or-exclude-one-test-with-gradle/)
+    // Usage: gradle test -PexcludeTests='**/ErlangModelApiTests*,**/ErlangExamplesTests*'
     if (project.hasProperty('excludeTests')) {
-        exclude project.property('excludeTests')
+        project.property('excludeTests').split(',').each { 
+            exclude it
+        }
     }
 }
 

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -178,6 +178,12 @@ test {
     useJUnitPlatform()
     ignoreFailures=true
     maxParallelForks=project.gradle.startParameter.maxWorkerCount
+
+    // Allow dynamic exclusion of tests (https://blog.jdriven.com/2017/10/run-one-or-exclude-one-test-with-gradle/)
+    // Usage: gradle test -PexcludeTests='**/ErlangModelApiTests*'
+    if (project.hasProperty('excludeTests')) {
+        exclude project.property('excludeTests')
+    }
 }
 
 spotbugs {

--- a/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
@@ -233,7 +233,7 @@ class TimeoutThread implements Runnable {
     public void run() {
         try {
             Thread.sleep(10000);
-            p.destroy();
+            p.destroyForcibly(); // Java >= 1.8
         } catch (InterruptedException e) {
         }
     }

--- a/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
@@ -187,11 +187,14 @@ public class ErlangTestDriver extends ABSTest implements BackendTestDriver {
                 // to do it. However, for now it seems to work.
                 if (br.ready()) { 
                     final String line = br.readLine();
-                    if (line == null)
+                    if (line == null) {
                         break;
-                    if (line.startsWith("RES=")) // see `genCode' above
+                    }
+
+                    else if (line.startsWith("RES=")) { // see `genCode' above
                         val = line.split("=")[1];
                         break; // there is no point to continue the loop, if the result has been retrieved.
+                    }
                 }
 
                 Thread.sleep(1000); // Wait 1 second before trying again

--- a/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
@@ -168,13 +168,14 @@ public class ErlangTestDriver extends ABSTest implements BackendTestDriver {
         pb.redirectErrorStream(true);
         Process p = pb.start();
 
+        final TimeoutThread tt = new TimeoutThread(p);
+        final Thread t = new Thread(tt);
+
         try ( // try-with-resources statement, which will ensure, that the declared resources are closed
             InputStream is = p.getInputStream();
             InputStreamReader isr = new InputStreamReader(is);
             BufferedReader br = new BufferedReader(isr)
         ) {
-            final TimeoutThread tt = new TimeoutThread(p);
-            final Thread t = new Thread(tt);
             t.start();
             // Search for result
             while (!tt.hasBeenAborted()) {
@@ -256,14 +257,13 @@ class TimeoutThread implements Runnable {
 
             if (p.isAlive()) { // If the test is still running by now, terminate it
                 p.destroyForcibly();
-                hasBeenAborted = true; // record, that the test has not stopped by itself.
+                this.aborted = true; // record, that the test has not stopped by itself.
             }
         } catch (InterruptedException e) {
-        } catch (IOException e) {
         } 
     }
 
-    public boolean hasBeenBorted() {
+    public boolean hasBeenAborted() {
         return this.aborted;
     }
 }


### PR DESCRIPTION
The deadlock tests do not terminate for me. Since it seems this is caused by reading input from dead threads, my changes close the used streams and introduce checks, whether the involved thread terminated etc.

Example log of running tests which did not terminate: https://ahbnr.de/jenkins/job/abstools-master/1/consoleFull

Log of executing tests after the changes introduced by this pull request have been applied: https://ahbnr.de/jenkins/job/abstools-mod/21/consoleFull

Also an optional property `excludeTests` has been added to the `build.gradle`. It allows to exclude tests when invoking gradle. Example:

`gradle test -PexcludeTests='**/ErlangModelApiTests*,**/ErlangExamplesTests*'`