### PR TITLE
Computation of free variables did not consider list literals.(identical to #257, but new branch)

### DIFF
--- a/frontend/src/main/java/org/abs_models/frontend/analyser/FreeVars.jrag
+++ b/frontend/src/main/java/org/abs_models/frontend/analyser/FreeVars.jrag
@@ -78,6 +78,15 @@ aspect VarUsage {
 		return res;
 	}
 
+    // List literals may contain for example VarUses
+    eq ListLiteral.getFreeVars() {
+		final HashSet<String> res = new HashSet<String>();
+        for (PureExp e : getPureExps()) {
+            res.addAll(e.getFreeVars());
+        }
+        return res;
+    }
+
 	eq Call.getFreeVars() {
 		HashSet<String> res = new HashSet<String>();
 		res.addAll(getCallee().getFreeVars());

--- a/frontend/src/test/java/org/abs_models/frontend/analyser/FreeVarTest.java
+++ b/frontend/src/test/java/org/abs_models/frontend/analyser/FreeVarTest.java
@@ -41,6 +41,12 @@ public class FreeVarTest extends FrontendTest {
     }
 
     @Test
+    public void listLiteral() {
+        final Exp e = getSecondExp("{ Bool b = True; List<Bool> l = list[b]; }");
+        assertEquals(e.getFreeVars(), "b");
+    }
+
+    @Test
     public void letExp2() {
         Exp e = getSecondExp("{ Bool b = True; Bool c = let (Bool d) = b in d; }");
         assertEquals(e.getFreeVars(), "b");

--- a/frontend/src/test/java/org/abs_models/frontend/parser/ParserTest.java
+++ b/frontend/src/test/java/org/abs_models/frontend/parser/ParserTest.java
@@ -9,9 +9,11 @@ import java.io.StringReader;
 import org.abs_models.frontend.FrontendTest;
 import org.abs_models.frontend.ast.CompilationUnit;
 import org.abs_models.frontend.ast.DeltaDecl;
+import org.abs_models.frontend.ast.Model;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import static org.junit.Assert.fail;
 
 public class ParserTest extends FrontendTest {
 
@@ -471,5 +473,19 @@ public class ParserTest extends FrontendTest {
     @Test
     public void anonymousFunctionNoParamBraces() {
         assertParseError("{ f(Int i => i)();}");
+    }
+
+    /**
+     * Before commit b79ac958b150bda90acb3c095bba0c30d97df5e4 this caused an
+     * error, since list literals were not considered when determining the
+     * free variables within an anonymous function (closure).
+     */
+    @Test
+    public void anonymousFunctionFreeVarsInList() throws Exception {
+        final String fileName = "abssamples/ClosureWithListLiterals.abs";
+        final Model m = assertParseFileOk(fileName);
+
+        if (m.hasParserErrors())
+            fail(m.getParserErrors().get(0).toString());
     }
 }

--- a/frontend/src/test/resources/abssamples/ClosureWithListLiterals.abs
+++ b/frontend/src/test/resources/abssamples/ClosureWithListLiterals.abs
@@ -1,0 +1,15 @@
+module ClosureWithListLiterals;
+
+def List<Int> run(fun)() = fun();
+
+// This caused a compiler error before b79ac958b150bda90acb3c095bba0c30d97df5e4,
+// since a global function is constructed from the anonymous one, deducing the
+// parameters from all free variables. However, free variables inside list
+// literals have not been considered before.
+def List<Int> test(Int r0) = run(
+    () => list[r0]
+  )();
+
+{
+  println("Main block");
+}


### PR DESCRIPTION
(This pull request is identical to #257, but uses a new branch directly based on upstream master)

The issue described in the title causes compiler errors when creating closures which use variables in list literals.

Example:
```
module MinimalExample;

def List<Int> run(fun)() = fun();

// This causes a compiler error on master, since a global function is constructed
// from the anonymous one, deducing the parameters from all free variables.
// However, free variables inside list literals are not considered.
// Error message: "Name r0 cannot be resolved."
def List<Int> test(Int r0) = run(
    () => list[r0]
  )();

{
  println("Main block");
}
``` 

The changes introduced by this branch adjust FreeVars.jrag to consider ListLiterals.
Also two tests have been added.

Building the branch results in no issues but 1 known test failure regarding the Maude backend:
https://ahbnr.de/jenkins/job/abstools-freeVarsInListLiterals/1/testReport/