### PR TITLE
Made second parameter of duration optional

### DIFF
--- a/frontend/src/main/java/org/abs_models/frontend/parser/XtextToJastAdd.java
+++ b/frontend/src/main/java/org/abs_models/frontend/parser/XtextToJastAdd.java
@@ -754,8 +754,12 @@ public class XtextToJastAdd {
             final org.abs_models.xtext.abs.DurationStatement value = (org.abs_models.xtext.abs.DurationStatement) stmt;
             final List<Annotation> annotations = annotationsfromXtext(value.getAnnotations());
             final PureExp min = pureExpFromXtext(value.getMin());
-            final PureExp max = pureExpFromXtext(value.getMax());
-            result = new DurationStmt(annotations, min, max);
+            if(value.getMax() != null){
+                final PureExp max = pureExpFromXtext(value.getMax());
+                result = new DurationStmt(annotations, min, max);
+            } else {
+                result = new DurationStmt(annotations, min, min);
+            }
         }
         else if(stmt instanceof org.abs_models.xtext.abs.ThrowStatement) {
             final org.abs_models.xtext.abs.ThrowStatement value = (org.abs_models.xtext.abs.ThrowStatement) stmt;
@@ -812,7 +816,11 @@ public class XtextToJastAdd {
         Guard result = null;
         if (guard instanceof org.abs_models.xtext.abs.DurationGuard) {
             final org.abs_models.xtext.abs.DurationGuard dguard = (org.abs_models.xtext.abs.DurationGuard) guard;
-            result = nodeWithLocation(new org.abs_models.frontend.ast.DurationGuard(pureExpFromXtext(dguard.getMin()), pureExpFromXtext(dguard.getMax())), guard);
+            if(dguard.getMax() != null){
+                result = nodeWithLocation(new org.abs_models.frontend.ast.DurationGuard(pureExpFromXtext(dguard.getMin()), pureExpFromXtext(dguard.getMax())), guard);
+            } else {
+                result = nodeWithLocation(new org.abs_models.frontend.ast.DurationGuard(pureExpFromXtext(dguard.getMin()), pureExpFromXtext(dguard.getMin())), guard);
+            }
         } else if (guard instanceof org.abs_models.xtext.abs.ExpressionGuard) {
             final org.abs_models.xtext.abs.ExpressionGuard eguard = (org.abs_models.xtext.abs.ExpressionGuard) guard;
             if (eguard.isClaim()) {

--- a/frontend/src/test/java/org/abs_models/frontend/parser/ParserTest.java
+++ b/frontend/src/test/java/org/abs_models/frontend/parser/ParserTest.java
@@ -59,6 +59,7 @@ public class ParserTest extends FrontendTest {
                 + "  Unit append(Int i){ skip; return null ; }}";
     }
 
+
     @Test
     public void testNothing() {
         // NO decls no block
@@ -496,5 +497,10 @@ public class ParserTest extends FrontendTest {
 
         if (m.hasParserErrors())
             fail(m.getParserErrors().get(0).toString());
+    }
+
+    @Test
+    public void testNewDuration() {
+        assertParse(" { await duration(1); } ");
     }
 }

--- a/org.abs_models.xtext/src/main/java/org/abs_models/xtext/Abs.xtext
+++ b/org.abs_models.xtext/src/main/java/org/abs_models/xtext/Abs.xtext
@@ -212,7 +212,7 @@ Statement : Annotations
         | {SuspendStatement.annotations=current}
             'suspend' ';'
         | {DurationStatement.annotations=current}
-            'duration' '(' min=Expression ',' max=Expression ')' ';'
+            'duration' '(' min=Expression (',' max=Expression)? ')' ';'
         | {ThrowStatement.annotations=current}
             'throw' exception=Expression ';'
         | {DieStatement.annotations=current}
@@ -234,7 +234,7 @@ AndGuard returns Guard
 
 SingleGuard returns Guard
     : {ExpressionGuard} expression=Expression claim?='?'?
-    | {DurationGuard} 'duration' '(' min=Expression ',' max=Expression ')'
+    | {DurationGuard} 'duration' '(' min=Expression (',' max=Expression)? ')'
     ;
 
 SwitchStatementBranch : pattern=Pattern '=>' body=Statement ;


### PR DESCRIPTION
Allows one to write `await duration(e)` instead of repeating `await duration(e,e)`.