### PR TITLE
Fix constant folding for #283

### DIFF
--- a/frontend/src/main/java/org/abs_models/frontend/analyser/ConstantFolding.jadd
+++ b/frontend/src/main/java/org/abs_models/frontend/analyser/ConstantFolding.jadd
@@ -3,6 +3,10 @@ aspect ConstantFolding {
 
     rewrite MinusExp {
         when (getOperand().isConstant()
+              && getOperand().getType().isIntType()
+              && ((IntLiteral) getOperand()).getContent().startsWith("-"))
+        to IntLiteral new IntLiteral(((IntLiteral)getOperand()).getContent().substring(1));
+        when (getOperand().isConstant()
               && getOperand().getType().isIntType())
         to IntLiteral new IntLiteral("-" + ((IntLiteral)getOperand()).getContent());
         when (getOperand().isConstant()

--- a/frontend/src/test/java/org/abs_models/backend/common/PrimitiveTypes.java
+++ b/frontend/src/test/java/org/abs_models/backend/common/PrimitiveTypes.java
@@ -116,6 +116,13 @@ public class PrimitiveTypes extends SemanticTests {
     }
 
     @Test
+    public void intDoubleMinusFolding() throws Exception {
+        // Test that constant folding does not result in literals like `--1`, which are invalid.
+        // See https://github.com/abstools/abstools/issues/283
+        assertEvalTrue("{ Int i =  -(0 - 1) + 1; Bool testresult = i == 2; }");
+    }
+
+    @Test
     public void ratMinus() throws Exception {
         assertEvalTrue("{ Rat x = -1/2; x = -x; Bool testresult = x == 1/2; }");
     }


### PR DESCRIPTION
Fixes the rewrite of unary minus as mentioned in #283.

When a `MinusExp` gets rewritten, it is first checked, if the inner constant starts with a "-". If it does, the resulting `IntegerLiteral` will simply remove this minus.