### PR TITLE
Use Streams-interface to filter builtin inheritance from pretty-print…

### DIFF
--- a/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
+++ b/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
@@ -1,6 +1,7 @@
 // -*- mode: java; tab-width: 4; -*-
 import java.io.PrintWriter;
 import org.abs_models.backend.prettyprint.*;
+import com.google.common.collect.Streams;
 
 aspect doPrettyPrinter {
 
@@ -815,9 +816,11 @@ aspect doPrettyPrinter {
         }
         stream.print("interface ");
         stream.print(getName());
-        if (getNumExtendedInterfaceUse() > 0) {
+	/* Filter `extends ABS.StdLib.Object, ...` */
+	Stream<InterfaceTypeUse> s = Streams.stream(getExtendedInterfaceUses()).filter(i -> !i.getName().startsWith("ABS.StdLib."));
+        if (s.count() > 0) {
             stream.print(" extends ");
-            getExtendedInterfaceUseList().doPrettyPrint(stream, formatter, ",");
+	    s.forEach(tu -> { tu.doPrettyPrint(stream, formatter); stream.print(", ");});
         }
         formatter.beforeOpenBrace();
         stream.println(" {");

--- a/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
+++ b/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
@@ -1,6 +1,7 @@
 // -*- mode: java; tab-width: 4; -*-
 import java.io.PrintWriter;
 import org.abs_models.backend.prettyprint.*;
+import java.util.stream.Collectors;
 import com.google.common.collect.Streams;
 
 aspect doPrettyPrinter {
@@ -816,11 +817,11 @@ aspect doPrettyPrinter {
         }
         stream.print("interface ");
         stream.print(getName());
-	/* Filter `extends ABS.StdLib.Object, ...` */
-	Stream<InterfaceTypeUse> s = Streams.stream(getExtendedInterfaceUses()).filter(i -> !i.getName().startsWith("ABS.StdLib."));
-        if (s.count() > 0) {
+	/* Filter `extends ABS.StdLib.Object, ...` by way of streams. */
+	String s = Streams.stream(getExtendedInterfaceUses()).filter(i -> !i.getName().startsWith("ABS.StdLib.")).map(tu -> tu.getName()).collect(Collectors.joining(", "));
+        if (s.length() > 0) {
             stream.print(" extends ");
-	    s.forEach(tu -> { tu.doPrettyPrint(stream, formatter); stream.print(", ");});
+            stream.print(s);
         }
         formatter.beforeOpenBrace();
         stream.println(" {");

--- a/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
+++ b/frontend/src/main/java/org/abs_models/backend/prettyprint/PrettyPrinter.jadd
@@ -818,7 +818,7 @@ aspect doPrettyPrinter {
         stream.print("interface ");
         stream.print(getName());
 	/* Filter `extends ABS.StdLib.Object, ...` by way of streams. */
-	String s = Streams.stream(getExtendedInterfaceUses()).filter(i -> !i.getName().startsWith("ABS.StdLib.")).map(tu -> tu.getName()).collect(Collectors.joining(", "));
+	String s = Streams.stream(getExtendedInterfaceUses()).filter(i -> !i.getName().equals(Constants.STDLIB_NAME+".Object")).map(tu -> tu.getName()).collect(Collectors.joining(", "));
         if (s.length() > 0) {
             stream.print(" extends ");
             stream.print(s);

--- a/frontend/src/test/java/org/abs_models/backend/prettyprint/PrettyPrinterTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/prettyprint/PrettyPrinterTests.java
@@ -51,6 +51,13 @@ public class PrettyPrinterTests extends ABSTest {
     }
 
     @Test
+    public void prettyPrinterNoStdLibTest() throws Exception {
+        String ms = "module Test; interface Foo {} interface Bar extends Bar {}";
+        Model m = assertParse(ms, Config.WITHOUT_MODULE_NAME, Config.WITHOUT_DESUGARING_AFTER_TYPECHECK);
+        assertEqualsAndParses(ms, m);
+    }
+
+    @Test
     public void prettyPrinterLiterals() throws Exception {
         String ms = readFile("abssamples/backend/PrettyPrinterTests/Literals.abs");
         Model m = assertParse(ms, Config.WITHOUT_MODULE_NAME, Config.WITHOUT_DESUGARING_AFTER_TYPECHECK);

--- a/frontend/src/test/java/org/abs_models/backend/prettyprint/PrettyPrinterTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/prettyprint/PrettyPrinterTests.java
@@ -52,7 +52,7 @@ public class PrettyPrinterTests extends ABSTest {
 
     @Test
     public void prettyPrinterNoStdLibTest() throws Exception {
-        String ms = "module Test; interface Foo {} interface Bar extends Bar {}";
+        String ms = "module Test; interface Foo {} interface Bar extends Foo {}";
         Model m = assertParse(ms, Config.WITHOUT_MODULE_NAME, Config.WITHOUT_DESUGARING_AFTER_TYPECHECK);
         assertEqualsAndParses(ms, m);
     }


### PR DESCRIPTION
…er. No more

```
interface Foo extends ABS.StdLib.Object
```