### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -33,5 +33,5 @@ jobs:
       uses: dorny/test-reporter@v1
       with:
         name: JUnit Tests
-        path: **/test/TEST-*.xml
+        path: '**/test/TEST-*.xml'
         reporter: java-junit

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         LANG: en_US.UTF-8
       with:
-        arguments: assemble
+        arguments: build -x check -x test
     - name: Run tests
       uses: eskatos/gradle-command-action@v1
       env:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,3 +29,14 @@ jobs:
         LANG: en_US.UTF-8
       with:
         arguments: test
+    - name: Test Report
+      # See https://github.com/marketplace/actions/test-reporter for
+      # how to set this up to handle pull requests from cloned
+      # repositories
+      uses: dorny/test-reporter@v1
+      # run this step even if previous step failed
+      if: success() || failure()
+      with:
+        name: JUnit Tests
+        path: **/test/TEST-*.xml
+        reporter: java-junit

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,12 +29,3 @@ jobs:
         LANG: en_US.UTF-8
       with:
         arguments: test
-    - name: Test Report
-      # See https://github.com/marketplace/actions/test-reporter for
-      # how to set this up to handle pull requests from cloned
-      # repositories
-      uses: dorny/test-reporter@v1
-      with:
-        name: JUnit Tests
-        path: **/test/TEST-*.xml
-        reporter: java-junit

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -34,8 +34,6 @@ jobs:
       # how to set this up to handle pull requests from cloned
       # repositories
       uses: dorny/test-reporter@v1
-      # run this step even if previous step failed
-      if: success() || failure()
       with:
         name: JUnit Tests
         path: **/test/TEST-*.xml

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,3 +29,9 @@ jobs:
         LANG: en_US.UTF-8
       with:
         arguments: test
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      with:
+        name: JUnit Tests
+        path: **/test/TEST-*.xml
+        reporter: java-junit

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,4 +17,10 @@ jobs:
     - name: Build with Gradle
       env:
         LANG: en_US.UTF-8
-      run: ./gradlew build -x check
+      run: ./gradlew build -x spotbugsMain -x spotbugsTest
+    # tests hang - try without gradle plugin
+    # - uses: eskatos/gradle-command-action@v1
+    #   env:
+    #     LANG: en_US.UTF-8
+    #   with:
+    #     arguments: build -x check -x test

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,21 +6,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Java
+      uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
         java-version: '11'
-    - uses: gleam-lang/setup-erlang@v1.1.2
+    - name: Install Erlang
+      uses: gleam-lang/setup-erlang@v1.1.2
       with:
         otp-version: '23.2'
-    - name: Build with Gradle
+    - name: Build abstools
+      uses: eskatos/gradle-command-action@v1
       env:
         LANG: en_US.UTF-8
-      run: ./gradlew build -x spotbugsMain -x spotbugsTest
-    # tests hang - try without gradle plugin
-    # - uses: eskatos/gradle-command-action@v1
-    #   env:
-    #     LANG: en_US.UTF-8
-    #   with:
-    #     arguments: build -x check -x test
+      with:
+        arguments: assemble
+    - name: Run tests
+      uses: eskatos/gradle-command-action@v1
+      env:
+        LANG: en_US.UTF-8
+      with:
+        arguments: test


### PR DESCRIPTION
Run CI integration via github actions instead of on CircleCI.  On CircleCI we had to create our own containers with build environment, on github everything is contained in one file.  Also, tests run on every checkin (takes ~20min) and we get a nice test report.

