### PR TITLE
Make return value of user-defined schedulers optional.

### DIFF
--- a/abs-docs/src/docs/asciidoc/schedulers.adoc
+++ b/abs-docs/src/docs/asciidoc/schedulers.adoc
@@ -39,8 +39,13 @@ def Process earliest_deadline_scheduler(List<Process> queue) =
 ----
 
 
-All schedulers must have a result type `Process` and must take an argument of
-type `List<Process>` as their first argument.
+All schedulers must have a result type `Process` or `Maybe<Process>` and must
+take an argument of type `List<Process>` as their first argument.
+
+If `Maybe<Process>` is used as a return type, the user-defined scheduler can
+decide not to schedule any process by returning `Nothing`.
+
+NOTE: The `Maybe<Process>` return type is supported by the Erlang backend only.
 
 [[sec:process-attributes]]
 === Processes and Process Attributes
@@ -128,3 +133,56 @@ def Process some_scheduler(List<Process> queue, Bool value) = head(queue); <2>
 <2> The scheduler `some_scheduler` has a second argument of type `Bool`
 <3> The current value of field `flag` will used as the second argument to `some_scheduler`
 
+The `Maybe<Process>` return type of schedulers can be utilized to enforce a
+specific process activation order.
+That is, the class `SharedResourceImpl` in the following example enforces that
+its methods `connect()`, `performAction()`, and `disconnect()` can only ever be
+executed in this order.
+For example, if `connect()` has not run yet, then the scheduler of
+`SharedResourceImpl` will not activate any method execution, until an
+activation for `connect()` is available:
+
+[source]
+.Example
+----
+module MainMod;
+import * from ABS.Scheduler;
+
+def Maybe<Process> resourceScheduler(List<Process> queue, Object connection) =
+  when method(head(queue)) == ".init" then Just(head(queue)) else <1>
+    let List<Process> permittedActivations = filter( <2>
+        (Process p) => 
+          when (connection == null) then
+            method(p) == "connect"
+          else
+            method(p) == "performAction" || method(p) == "disconnect" 
+      )(queue)
+    in
+      case permittedActivations {
+        Nil => Nothing | <3>
+        Cons(p, _) => Just(
+          head(permittedActivations)
+        )
+      };
+
+interface SharedResource {
+  Unit connect();
+  Unit performAction();
+  Unit disconnect();
+}
+
+class Connection {}
+
+[Scheduler: resourceScheduler(queue, connection)]
+class SharedResourceImpl implements SharedResource {
+  Object connection;
+
+  Unit connect() { connection = new Connection(); println("connect"); }
+  Unit performAction()  { println("performAction"); }
+  Unit disconnect() { connection = null; println("disconnect"); }
+}
+----
+<1> `.init` must always be executed first.
+<2> Here, we filter the available `Process` instances for those that can be
+    executed in the current state.
+<3> If no available activation is viable, the scheduler returns `Nothing`.

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/SchedulerChecker.java
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/SchedulerChecker.java
@@ -47,8 +47,23 @@ public class SchedulerChecker extends DefaultTypeSystemExtension {
         }
         FunctionDecl sd = (FunctionDecl)s.getDecl();
         // check scheduling function return type
-        boolean schedulerTypeCorrect = scheduler_type.isDataType()
-            && ((DataTypeType)scheduler_type).getQualifiedName().equals("ABS.Scheduler.Process");
+        final boolean schedulerTypeCorrect;
+        if (scheduler_type.isDataType()) {
+            final DataTypeType scheduler_data_type = (DataTypeType) scheduler_type;
+
+            // A sheduler function must either have the return type
+            // ABS.Scheduler.Process, or ABS.StdLib.Maybe<ABS.Scheduler.Process>
+            schedulerTypeCorrect =
+                      scheduler_data_type.getQualifiedName().equals("ABS.Scheduler.Process")
+                ||       scheduler_data_type.getQualifiedName().equals("ABS.StdLib.Maybe")
+                      && scheduler_data_type.numTypeArgs() == 1
+                      && scheduler_data_type.getTypeArgs().get(0).isDataType()
+                      && ((DataTypeType) scheduler_data_type.getTypeArgs().get(0))
+                             .getQualifiedName().equals("ABS.Scheduler.Process");
+        } else {
+            schedulerTypeCorrect = false;
+        }
+
         // check scheduling function first arg, pt.1: are we a list?
         boolean schedulerFunFirstArgCorrect = sd.getNumParam() > 0 &&
             sd.getParam(0).getType().getQualifiedName().equals("ABS.StdLib.List");

--- a/frontend/src/test/java/org/abs_models/backend/erlang/SchedulerReturnValueTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/erlang/SchedulerReturnValueTests.java
@@ -1,0 +1,189 @@
+package org.abs_models.backend.erlang;
+
+import org.abs_models.ABSTest;
+import org.junit.Test;
+
+public class SchedulerReturnValueTests extends ABSTest {
+    private final ErlangTestDriver driver = new ErlangTestDriver();
+
+    @Test
+    public void plainReturnTypeWorks() throws Exception {
+        driver.assertEvalTrue(
+                String.join(System.lineSeparator(),
+                    "module MainMod;",
+                    "import * from ABS.Scheduler;",
+                    
+                    "def Process plainScheduler(List<Process> queue) = head(queue);",
+                    
+                    "interface Testable {",
+                      "Bool test();",
+                    "}",
+                    
+                    "[Scheduler: plainScheduler(queue)]",
+                    "class C implements Testable {",
+                      "Int counter = 0;",
+                    
+                      "Unit inc() {",
+                        "counter = counter + 1;",
+                      "}",
+                    
+                      "Bool test() {",
+                        "this!inc();",
+                        "this!inc();",
+                        "this!inc();",
+                        "await counter == 3;",
+                    
+                        "return True;",
+                      "}",
+                    "}",
+                    
+                    "{",
+                      "Testable t = new C();",
+                      "Bool testresult = await t!test();",
+                    "}"
+                )
+        );
+    }
+
+    @Test
+    public void maybeReturnTypeWorks() throws Exception {
+        driver.assertEvalTrue(
+                String.join(System.lineSeparator(),
+                    "module MainMod;",
+                    "import * from ABS.Scheduler;",
+                    
+                    "def Maybe<Process> maybeScheduler(List<Process> queue) = Just(head(queue));",
+                    
+                    "interface Testable {",
+                      "Bool test();",
+                    "}",
+                    
+                    "[Scheduler: maybeScheduler(queue)]",
+                    "class C implements Testable {",
+                      "Int counter = 0;",
+                    
+                      "Unit inc() {",
+                        "counter = counter + 1;",
+                      "}",
+                    
+                      "Bool test() {",
+                        "this!inc();",
+                        "this!inc();",
+                        "this!inc();",
+                        "await counter == 3;",
+                    
+                        "return True;",
+                      "}",
+                    "}",
+                    
+                    "{",
+                      "Testable t = new C();",
+                      "Bool testresult = await t!test();",
+                    "}"
+                )
+        );
+    }
+
+    @Test
+    public void complexScheduler() throws Exception {
+        // This scheduler ensures that a resource is accessed in the correct order: connect -> perform action -> disconnect
+        driver.assertEvalTrue(
+                String.join(System.lineSeparator(),
+                    "module MainMod;",
+                    "import * from ABS.Scheduler;",
+                    
+                    "def Maybe<Process> resourceScheduler(List<Process> queue, Object connection) =",
+                      "when method(head(queue)) == \".init\" || method(head(queue)) == \"isProtocolOk\" then Just(head(queue)) else",
+                        "let List<Process> permittedActivations = filter(",
+                            "(Process p) => ",
+                              "when (connection == null) then",
+                                "method(p) == \"connect\"",
+                              "else",
+                                "method(p) == \"performAction\" || method(p) == \"disconnect\" ",
+                          ")(queue)",
+                        "in",
+                          "case permittedActivations {",
+                            "Nil => Nothing |",
+                            "Cons(p, _) => Just(",
+                              "head(permittedActivations)",
+                            ")",
+                          "};",
+                    
+                    "interface SharedResource {",
+                      "Unit connect();",
+                      "Unit performAction();",
+                      "Unit disconnect();",
+                    
+                      "Bool isProtocolOk();",
+                    "}",
+                    
+                    "class Connection {}",
+                    
+                    "[Scheduler: resourceScheduler(queue, connection)]",
+                    "class SharedResourceImpl implements SharedResource {",
+                      "Object connection;",
+                    
+                      "Int correctOrder = 0;",
+                    
+                      "Unit connect() {",
+                        "if (connection == null) {",
+                          "correctOrder = 1;",
+                        "}",
+                    
+                        "connection = new Connection();",
+                        "println(\"connect\");",
+                      "}",
+                      "Unit performAction()  {",
+                        "if (connection != null && correctOrder == 1) {",
+                          "correctOrder = 2;",
+                        "}",
+                    
+                        "println(\"performAction\");",
+                      "}",
+                    
+                      "Unit disconnect() {",
+                        "if (connection != null && correctOrder == 2) {",
+                          "correctOrder = 3;",
+                        "}",
+                    
+                        "connection = null;",
+                        "println(\"disconnect\");",
+                      "}",
+                    
+                      "Bool isProtocolOk() {",
+                        "return correctOrder == 3;",
+                      "}",
+                    "}",
+                    
+                    "interface Testing {",
+                      "Bool test();",
+                    "}",
+                    
+                    "class Tester implements Testing {",
+                      "Bool test() {",
+                        "SharedResource r = new SharedResourceImpl();",
+                    
+                        "Fut<Unit> action = r!performAction();",
+                        "await duration(5);",
+                        "r!connect();",
+                    
+                        "await action?;",
+                        "await r!disconnect();",
+                    
+                        "Bool ok = await r!isProtocolOk();",
+                    
+                        "return ok;",
+                      "}",
+                    "}",
+                    
+                    "{",
+                      "Testing t = new Tester();",
+                      "Bool testresult = await t!test();",
+                    "}"
+                )
+        );
+    }
+}
+
+
+


### PR DESCRIPTION
Originally, user-defined schedulers have the return type `Process` and must always return a `Process` instance to be activated.

This pull request changes this requirement: Now, user-defined schedulers may also have the return type `Maybe<Process>` and do not have to return a `Process` instance.
That is, if `Maybe<Process>` is used as a return type, `Just(p)` must be returned if a `Process p` shall be activated, and `Nothing` is to be returned, if no `Process` should be activated:

```abs
// This scheduler always activates the first Process in the queue
def Maybe<Process> scheduleFirst(List<Process> queue) = Just(head(queue));
// This scheduler never activates a Process
def Maybe<Process> neverSchedule(List<Process> queue) = Nothing;
```

I utilized this feature in my bachelor thesis to globally enforce session type-based interaction protocols at runtime [1, sections 3.5, 3.5.6, and 5.1].
This pull request does not include the support for session types and their enforcement, but the ability to delay process activations can still be used to manually implement classes that enforce certain activation orders for their methods:

The class `SharedResourceImpl` in the following example enforces that its methods connect(), performAction(), and disconnect() can only ever be executed in this order. For example, if connect() has not run yet, then the scheduler of `SharedResourceImpl` will not activate any method execution, until an activation for connect() is available:

```abs
def Maybe<Process> resourceScheduler(List<Process> queue, Object connection) =
  when method(head(queue)) == ".init" then Just(head(queue)) else 
    let List<Process> permittedActivations = filter( 
        (Process p) =>
          when (connection == null) then
            method(p) == "connect"
          else
            method(p) == "performAction" || method(p) == "disconnect"
      )(queue)
    in
      case permittedActivations {
        Nil => Nothing | 
        Cons(p, _) => Just(
          head(permittedActivations)
        )
      };

interface SharedResource {
  Unit connect();
  Unit performAction();
  Unit disconnect();
}

class Connection {}

[Scheduler: resourceScheduler(queue, connection)]
class SharedResourceImpl implements SharedResource {
  Object connection;

  Unit connect() { connection = new Connection(); println("connect"); }
  Unit performAction()  { println("performAction"); }
  Unit disconnect() { connection = null; println("disconnect"); }
}
```
Besides the implementation of the feature, this pull request includes:
* tests in https://github.com/ahbnr/abstools/blob/SchedulersWithOptionalResult/frontend/src/test/java/org/abs_models/backend/erlang/SchedulerReturnValueTests.java
* documentation in https://raw.githubusercontent.com/ahbnr/abstools/SchedulersWithOptionalResult/abs-docs/src/docs/asciidoc/schedulers.adoc

[1] https://raw.githubusercontent.com/ahbnr/SessionTypeABS/master/thesis/thesis_final_pdfa.pdf