### PR TITLE
Fix warning in generated code, allow passing null for arguments

### DIFF
--- a/frontend/src/main/java/org/abs_models/backend/java/codegeneration/GenerateJava.jadd
+++ b/frontend/src/main/java/org/abs_models/backend/java/codegeneration/GenerateJava.jadd
@@ -63,7 +63,7 @@ aspect GenerateJava {
                 stream.println("}");
 
                 stream.println("public java.lang.String getClassName() { return \"Main\"; }");
-                stream.println("public java.util.List<java.lang.String> getFieldNames() { return java.util.Collections.EMPTY_LIST; }");
+                stream.println("public java.util.List<java.lang.String> getFieldNames() { return java.util.Collections.emptyList(); }");
                 stream.println("public " + mainName + "(" + COG.class.getName() + " cog) { super(cog); }");
                 stream.println("public java.util.List<java.util.Map<java.lang.String, java.lang.Object>> getHttpCallableMethodInfo() { throw new UnsupportedOperationException(\"method 'getHttpCallableMethodInfo' cannot be called on Main block\");} ");
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/RuntimeOptions.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/RuntimeOptions.java
@@ -241,6 +241,7 @@ public class RuntimeOptions {
     }
 
     void parseCommandLineArgs(String[] args) {
+        if (args == null) return;
         ArrayList<String> arguments = new ArrayList<>(Arrays.asList(args));
         ListIterator<String> argslist = arguments.listIterator();
         ArrayList<Option> remainingOptions = new ArrayList<>(options);

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/Type.java
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/Type.java
@@ -22,7 +22,7 @@ public abstract class Type {
 
     protected Map<Object,Object> metaData = new HashMap<>();
     {
-        metaData.put(ANNOTATION_KEY, Collections.EMPTY_LIST);
+        metaData.put(ANNOTATION_KEY, Collections.emptyList());
     }
 
     public Type withAnnotations(org.abs_models.frontend.ast.List<Annotation> anns) {


### PR DESCRIPTION
- Use `Collections.emptyList()` instead of `Collections.EMPTY_LIST` to eliminate unchecked conversion warning.

- For convenience, allow calling `Main.main(null)`, this is useful when starting an ABS model from Java code instead of from the command line.