### PR TITLE
Document adding of runtime dependency on abstools.jar

### DIFF
--- a/abs-docs/src/docs/asciidoc/backends.adoc
+++ b/abs-docs/src/docs/asciidoc/backends.adoc
@@ -94,6 +94,12 @@ ext {
     absToolsDir = new File("${gradle.gradleUserHomeDir}/caches/abstools")
 }
 
+dependencies {
+    // Any other dependencies here ...
+    implementation files(getLatestAbsFrontendJar())
+}
+
+
 task downloadAbsFrontend {
     description 'Downloads the latest absfrontend.jar from GitHub releases'
     def taskAbsToolsDir = project.ext.absToolsDir


### PR DESCRIPTION
abstools.jar contains the runtime library of the Java backend, so is needed not only to compile ABS.