### PR TITLE
Tweak abs-in-gradle instructions

### DIFF
--- a/abs-docs/src/docs/asciidoc/backends.adoc
+++ b/abs-docs/src/docs/asciidoc/backends.adoc
@@ -157,7 +157,7 @@ task compileAbs(type: Exec, dependsOn: downloadAbsFrontend) {
     description = 'Compiles ABS.'
     inputs.dir 'src/main/abs'
     outputs.dir 'build/abs'
-    commandLine 'java', '-jar', project.ext.absToolsDir.toString() + '/absfrontend.jar', '--java', '-d', 'build/abs/',
+    commandLine 'java', '-jar', project.ext.absToolsDir.toString() + '/absfrontend.jar', '--java', '-d', 'build/abs/', '--sourceonly',
         *fileTree(dir: 'src/main/abs', include: '**/*.abs').collect { it.absolutePath }
 }
 


### PR DESCRIPTION
Only generate the Java sources when compiling abs; the standard Java compile step will generate the class files.