### PR TITLE
Make View objects easier to spot and safe to create

### DIFF
--- a/frontend/src/main/java/org/abs_models/backend/java/absunit/ABSTestObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/absunit/ABSTestObserver.java
@@ -79,7 +79,7 @@ public class ABSTestObserver extends RegistratingObserver implements FutObserver
     @Override
     public void taskCreated(TaskView task) {
         task.registerTaskListener(this);
-        task.getFuture().registerFutObserver(this);
+        task.getFutView().registerFutObserver(this);
     }
 
     @Override
@@ -124,8 +124,8 @@ public class ABSTestObserver extends RegistratingObserver implements FutObserver
 
     @Override
     public void stackFrameCreated(TaskView task, TaskStackFrameView stackFrame) {
-        if (isUnitTest(stackFrame.getMethod().getName())) {
-            pushSyncTestInfo(task, new SyncTestInfo(task, stackFrame.getStack().getFrames().size()));
+        if (isUnitTest(stackFrame.getMethodView().getName())) {
+            pushSyncTestInfo(task, new SyncTestInfo(task, stackFrame.getStackView().getFrameViews().size()));
             model.testStarted(task);
         }
     }
@@ -176,7 +176,7 @@ public class ABSTestObserver extends RegistratingObserver implements FutObserver
     @Override
     public void stackFrameRemoved(TaskView task, TaskStackFrameView oldFrame) {
         synchronized (syncTests) {
-            if (isUnitTest(oldFrame.getMethod().getName())) {
+            if (isUnitTest(oldFrame.getMethodView().getName())) {
                 model.testFinished(task);
                 pop(task.getID());
             }

--- a/frontend/src/main/java/org/abs_models/backend/java/absunit/TestModel.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/absunit/TestModel.java
@@ -29,10 +29,10 @@ public class TestModel {
         final String className;
         final List<Object> testMethodArguments;
         final LinkedList<Object> arguments = new LinkedList<>();
-        if (task.getStack().hasFrames()) {
-            final TaskStackFrameView currentF = task.getStack().getCurrentFrame();
-            testMethod = currentF.getMethod().getName();
-            className = currentF.getMethod().getClassView().getName();
+        if (task.getStackView().hasFrames()) {
+            final TaskStackFrameView currentF = task.getStackView().getCurrentFrameView();
+            testMethod = currentF.getMethodView().getName();
+            className = currentF.getMethodView().getClassView().getName();
 
             for (String parameterName : currentF.getVariableNames()) {
                 arguments.add(currentF.getValue(parameterName));
@@ -40,19 +40,19 @@ public class TestModel {
 
         } else {
             testMethod = task.getMethodName();
-            className  = task.getTarget().getClassName();
+            className  = task.getTargetObjectView().getClassName();
             arguments.addAll(task.getArgs());
         }
 
-        if (!task.getStack().hasFrames()) {
+        if (!task.getStackView().hasFrames()) {
             System.out.println("Not yet started " + testMethod + " for task " + task.getID());
         } else {
-            System.out.println("Test " + task.getStack().getCurrentFrame().getMethod() + " task: " + task.getID());
+            System.out.println("Test " + task.getStackView().getCurrentFrameView().getMethodView() + " task: " + task.getID());
         }
 
         final TestStatus newTest = new TestStatus(task.getID(), testMethod, className,
                 arguments,
-                task.getStack().getFrames(), TestStatus.Status.ACTIVE);
+                task.getStackView().getFrameViews(), TestStatus.Status.ACTIVE);
 
         push(newTest);
 
@@ -183,7 +183,7 @@ public class TestModel {
 
     public void taskStep(TaskView task, String fileName, int line) {
         TestStatus status = peek(task.getID());
-        int depth = task.getStack().getFrames() == null ? 0 : task.getStack().getFrames().size();
+        int depth = task.getStackView().getFrameViews() == null ? 0 : task.getStackView().getFrameViews().size();
         if (status != null && status.depth() == depth) {
             status.updatePos(fileName, line);
         }

--- a/frontend/src/main/java/org/abs_models/backend/java/debugging/DebugModel.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/debugging/DebugModel.java
@@ -45,7 +45,7 @@ public class DebugModel implements TaskObserver, TaskSchedulerObserver {
     }
 
     public void cogCreated(COGView cog, ObjectView initialObject) {
-        cog.getScheduler().registerTaskSchedulerObserver(this);
+        cog.getSchedulerView().registerTaskSchedulerObserver(this);
         ArrayList<DebugModelListener> localList;
         COGInfo info = new COGInfo(cog, initialObject);
         synchronized (this) {
@@ -97,7 +97,7 @@ public class DebugModel implements TaskObserver, TaskSchedulerObserver {
         task.registerTaskListener(this);
         TaskInfo info = addInfoLine(task);
 
-        COGInfo cinfo = cogInfo.get(task.getCOG());
+        COGInfo cinfo = cogInfo.get(task.getCOGView());
         cinfo.addTask(info);
         cogInfoChanged(cinfo);
     }

--- a/frontend/src/main/java/org/abs_models/backend/java/debugging/GraphicalDebugger.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/debugging/GraphicalDebugger.java
@@ -550,7 +550,7 @@ class TaskTable extends JPanel {
                 return "" + line.task.getID();
             }
             case 1: {
-                ObjectView source = line.task.getSource();
+                ObjectView source = line.task.getSourceObjectView();
                 if (source != null) {
                     return source.toString();
                 }
@@ -558,7 +558,7 @@ class TaskTable extends JPanel {
 
             }
             case 2: {
-                return line.task.getTarget().toString();
+                return line.task.getTargetObjectView().toString();
             }
             case 3: {
                 StringBuilder sb = new StringBuilder();
@@ -586,9 +586,9 @@ class TaskTable extends JPanel {
                 }
                 return "";
             case 6:
-                return "" + line.task.getCOG().getID();
+                return "" + line.task.getCOGView().getID();
             case 7: {
-                FutView fut = line.task.getFuture();
+                FutView fut = line.task.getFutView();
                 if (fut.isResolved())
                     return "" + fut.getValue();
                 else
@@ -679,7 +679,7 @@ class COGTree extends JPanel {
                 lbl = new JLabel("COG " + cogInfo.cog.getID() + " [" + cogInfo.initialObject + "]");
             } else if (value instanceof TaskInfo) {
                 TaskInfo taskInfo = (TaskInfo) value;
-                lbl = new JLabel("Task " + taskInfo.task.getID() + " (" + taskInfo.task.getTarget() + "."
+                lbl = new JLabel("Task " + taskInfo.task.getID() + " (" + taskInfo.task.getTargetObjectView() + "."
                         + taskInfo.task.getMethodName() + ")");
 
                 lbl.setBackground(GraphicalDebugger.getColor(taskInfo.state));
@@ -720,7 +720,7 @@ class COGTree extends JPanel {
             TreeNode node = tasks.get(line);
             treeModel.nodeChanged(node);
 
-            DefaultMutableTreeNode cogNode = cogs.get(line.task.getCOG());
+            DefaultMutableTreeNode cogNode = cogs.get(line.task.getCOGView());
             TreeNode objectsNode = cogNode.getChildAt(0);
             for (int i = 0; i < objectsNode.getChildCount(); i++) {
                 TreeNode objectNode = objectsNode.getChildAt(i);
@@ -735,7 +735,7 @@ class COGTree extends JPanel {
             DefaultMutableTreeNode newNode = new DefaultMutableTreeNode(line);
             tasks.put(line, newNode);
             DefaultMutableTreeNode tasksNode = (DefaultMutableTreeNode) cogs.get(
-                    debugModel.getCOGInfo(line.task.getCOG()).cog).getChildAt(1);
+                    debugModel.getCOGInfo(line.task.getCOGView()).cog).getChildAt(1);
             treeModel.insertNodeInto(newNode, tasksNode, tasksNode.getChildCount());
             tree.scrollPathToVisible(new TreePath(newNode.getPath()));
 
@@ -777,7 +777,7 @@ class COGTree extends JPanel {
         }
 
         private void addObjectNode(ObjectView o) {
-            DefaultMutableTreeNode objectsNode = (DefaultMutableTreeNode) cogs.get(o.getCOG()).getChildAt(0);
+            DefaultMutableTreeNode objectsNode = (DefaultMutableTreeNode) cogs.get(o.getCOGView()).getChildAt(0);
             DefaultMutableTreeNode newNode = new DefaultMutableTreeNode(o);
             treeModel.insertNodeInto(newNode, objectsNode, objectsNode.getChildCount());
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicClass.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicClass.java
@@ -128,12 +128,16 @@ public class ABSDynamicClass implements ABSClass {
         return nextVersion;
     }
 
-    private View __view;
-    public synchronized ClassManipulator getView() {
-        if (__view == null) {
-            __view = new View();
+    private View view;
+    public ClassManipulator getView() {
+        if (view == null) {
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
         }
-        return __view;
+        return view;
     }
 
     private class View implements ClassManipulator {

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicObject.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicObject.java
@@ -112,17 +112,21 @@ public class ABSDynamicObject extends ABSObject {
 
 
 
-    public synchronized ObjectView getView() {
-        if (__view == null) {
-            __view = new View();
+    public ObjectView getView() {
+        if (view == null) {
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
         }
-        return __view;
+        return view;
     }
 
     private class View implements ObjectView {
 
         @Override
-        public COGView getCOG() {
+        public COGView getCOGView() {
             return __cog.getView();
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSFut.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSFut.java
@@ -258,11 +258,15 @@ public abstract class ABSFut<V> extends ABSBuiltInDataType
     }
 
 
-    protected volatile View view;
+    protected View view;
 
-    public synchronized FutView getView() {
+    public FutView getView() {
         if (view == null) {
-            view = createView();
+            synchronized(this) {
+                if (view == null) {
+                    view = createView();
+                }
+            }
         }
         return view;
     }
@@ -289,7 +293,7 @@ public abstract class ABSFut<V> extends ABSBuiltInDataType
 
 
         @Override
-        public TaskView getResolvingTask() {
+        public TaskView getResolvingTaskView() {
             return null;
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSGuard.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSGuard.java
@@ -62,8 +62,13 @@ public abstract class ABSGuard {
     private GuardView view;
 
     public GuardView getView() {
-        if (view == null)
-            view = new View();
+        if (view == null) {
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
+        }
         return view;
     }
 
@@ -89,15 +94,15 @@ public abstract class ABSGuard {
             return ABSGuard.this instanceof ABSAndGuard;
         }
 
-        public GuardView getLeftGuard() {
+        public GuardView getLeftGuardView() {
             return ((ABSAndGuard) ABSGuard.this).getLeftGuard().getView();
         }
 
-        public GuardView getRightGuard() {
+        public GuardView getRightGuardView() {
             return ((ABSAndGuard) ABSGuard.this).getRightGuard().getView();
         }
 
-        public FutView getFuture() {
+        public FutView getFutView() {
             return ((ABSFutureGuard) ABSGuard.this).fut.getView();
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
@@ -75,13 +75,15 @@ public abstract class ABSObject implements ABSRef {
         }
     }
 
-    protected volatile ObjectView __view;
+    protected ObjectView view;
 
-    public synchronized ObjectView getView() {
-        if (__view == null) {
-            __view = new View();
+    public ObjectView getView() {
+        if (view == null) {
+            synchronized(this) {
+                if (view == null) view = new View();
+            }
         }
-        return __view;
+        return view;
     }
 
     protected Object getFieldValue(String fieldName) throws NoSuchFieldException {
@@ -91,7 +93,7 @@ public abstract class ABSObject implements ABSRef {
     private class View implements ObjectView, ClassView {
 
         @Override
-        public COGView getCOG() {
+        public COGView getCOGView() {
             return __cog.getView();
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSTaskFut.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSTaskFut.java
@@ -69,7 +69,7 @@ public class ABSTaskFut<V> extends ABSFut<V> {
 
     private class TaskFutView extends View {
         @Override
-        public TaskView getResolvingTask() {
+        public TaskView getResolvingTaskView() {
             return ABSTaskFut.this.resolvingTask.getView();
         }
     }

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/COG.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/COG.java
@@ -164,9 +164,13 @@ public class COG {
 
     private View view;
 
-    public synchronized COGView getView() {
+    public COGView getView() {
         if (view == null) {
-            view = new View();
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
         }
         return view;
     }
@@ -227,7 +231,7 @@ public class COG {
         }
 
         @Override
-        public TaskSchedulerView getScheduler() {
+        public TaskSchedulerView getSchedulerView() {
             return scheduler.getView();
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/Task.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/Task.java
@@ -110,7 +110,7 @@ public class Task<T extends ABSRef> implements Runnable {
 
     public synchronized void setLocalVariable(String name, Object v) {
         if (stack != null) {
-            Frame f = stack.getCurrentFrame();
+            Frame f = stack.getCurrentFrameView();
             f.setValue(name,v);
             if (view != null) {
                 view.localVariableChanged(f,name,v);
@@ -222,18 +222,19 @@ public class Task<T extends ABSRef> implements Runnable {
                 + "]";
     }
 
-    private volatile View view;
+    private View view;
 
-    private Object viewCreationLock = new Object();
     private boolean finished = false;
 
     public TaskView getView() {
-        synchronized(viewCreationLock) {
         if (view == null) {
-            view = new View();
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
         }
         return view;
-        }
     }
 
     public synchronized Thread getExecutingThread() {
@@ -255,7 +256,7 @@ public class Task<T extends ABSRef> implements Runnable {
         private List<TaskObserver> taskListener;
 
         @Override
-        public TaskView getSender() {
+        public TaskView getSenderView() {
             if (call.getSender() == null)
                 return null;
             return call.getSender().getView();
@@ -298,14 +299,14 @@ public class Task<T extends ABSRef> implements Runnable {
         }
 
         @Override
-        public ObjectView getSource() {
+        public ObjectView getSourceObjectView() {
             if (call.getSource() == null)
                 return null;
             return call.getSource().getView();
         }
 
         @Override
-        public ObjectView getTarget() {
+        public ObjectView getTargetObjectView() {
             return ((ABSObject)call.getTarget()).getView();
         }
 
@@ -328,7 +329,7 @@ public class Task<T extends ABSRef> implements Runnable {
         }
 
         @Override
-        public COGView getCOG() {
+        public COGView getCOGView() {
             return Task.this.getCOG().getView();
         }
 
@@ -343,7 +344,7 @@ public class Task<T extends ABSRef> implements Runnable {
         }
 
         @Override
-        public FutView getFuture() {
+        public FutView getFutView() {
             return future.getView();
         }
 
@@ -373,7 +374,7 @@ public class Task<T extends ABSRef> implements Runnable {
         }
 
         @Override
-        public TaskStackView getStack() {
+        public TaskStackView getStackView() {
             return stack;
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/TaskStack.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/TaskStack.java
@@ -68,23 +68,23 @@ class TaskStack implements TaskStackView {
         }
 
         @Override
-        public TaskStackView getStack() {
+        public TaskStackView getStackView() {
             return TaskStack.this;
         }
 
         @Override
-        public MethodView getMethod() {
+        public MethodView getMethodView() {
             return method;
         }
     }
 
     @Override
-    public List<? extends TaskStackFrameView> getFrames() {
+    public List<? extends TaskStackFrameView> getFrameViews() {
         return Collections.unmodifiableList(frames);
     }
 
     @Override
-    public synchronized Frame getCurrentFrame() {
+    public synchronized Frame getCurrentFrameView() {
         return frames.get(frames.size()-1);
     }
 
@@ -94,7 +94,7 @@ class TaskStack implements TaskStackView {
     }
 
     @Override
-    public TaskView getTask() {
+    public TaskView getTaskView() {
         return task.getView();
     }
 }

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/COGView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/COGView.java
@@ -5,7 +5,7 @@
 package org.abs_models.backend.java.observing;
 
 public interface COGView {
-    TaskSchedulerView getScheduler();
+    TaskSchedulerView getSchedulerView();
 
     void registerObjectCreationListener(ObjectCreationObserver listener);
 

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/ConsoleObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/ConsoleObserver.java
@@ -38,7 +38,7 @@ public class ConsoleObserver extends RegistratingObserver implements FutObserver
     @Override
     public void objectCreated(ObjectView o) {
         super.objectCreated(o);
-        show(objectString(o)+" created in COG["+o.getCOG().getID()+"]");
+        show(objectString(o)+" created in COG["+o.getCOGView().getID()+"]");
     }
     
     @Override
@@ -53,14 +53,14 @@ public class ConsoleObserver extends RegistratingObserver implements FutObserver
     @Override
     public void taskCreated(TaskView task) {
         show("Task["+task.getID()+"] created ("
-                +objectString(task.getTarget())+
+                +objectString(task.getTargetObjectView())+
                 "!"+task.getMethodName()+
                 "("+StringUtil.iterableToString(task.getArgs(), ",")+
                 ")"+
                 ")");
 
         task.registerTaskListener(this);
-        task.getFuture().registerFutObserver(this);
+        task.getFutView().registerFutObserver(this);
     }
     
     @Override
@@ -106,7 +106,7 @@ public class ConsoleObserver extends RegistratingObserver implements FutObserver
 
     @Override
     public void stackFrameCreated(TaskView task, TaskStackFrameView stackFrame) {
-        show("Task["+task.getID()+"] called "+stackFrame.getMethod().getClassView().getName()+"."+stackFrame.getMethod().getName());
+        show("Task["+task.getID()+"] called "+stackFrame.getMethodView().getClassView().getName()+"."+stackFrame.getMethodView().getName());
     }
 
     @Override

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/FutView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/FutView.java
@@ -5,7 +5,7 @@
 package org.abs_models.backend.java.observing;
 
 public interface FutView {
-    TaskView getResolvingTask();
+    TaskView getResolvingTaskView();
 
     boolean isResolved();
 

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/GuardView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/GuardView.java
@@ -36,19 +36,19 @@ public interface GuardView {
      * Return the left contained guard of an AndGuard.  Only call this method
      * if `isAndGuard` returns true.
      */
-    GuardView getLeftGuard();
+    GuardView getLeftGuardView();
 
     /**
      * Return the right contained guard of an AndGuard.  Only call this method
      * if `isAndGuard` returns true.
      */
-    GuardView getRightGuard();
+    GuardView getRightGuardView();
 
     /**
      * Return the contained future of a FutureGuard.  Only call this method if
      * `isFutureGuard` returns true.
      */
-    FutView getFuture();
+    FutView getFutView();
 
     /**
      * Returns the minimum wakeup time of a DurationGuard.  Only call this

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectView.java
@@ -7,7 +7,7 @@ package org.abs_models.backend.java.observing;
 import java.util.List;
 
 public interface ObjectView {
-    COGView getCOG();
+    COGView getCOGView();
 
     ClassView getClassView();
 

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/RegistratingObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/RegistratingObserver.java
@@ -18,7 +18,7 @@ public abstract class RegistratingObserver extends DefaultCompleteObserver {
     @Override
     public void newCOGCreated(COGView cog, ObjectView initialObject) {
         cog.registerObjectCreationListener(this);
-        cog.getScheduler().registerTaskSchedulerObserver(this);
+        cog.getSchedulerView().registerTaskSchedulerObserver(this);
         initialObject.registerObjectObserver(this);
     }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/TaskSchedulerView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/TaskSchedulerView.java
@@ -14,23 +14,23 @@ public interface TaskSchedulerView {
      * are suspended on an unstable guard, i.e., a guard that may become false
      * after it was true. Such tasks are in the suspendedTasks list.
      */
-    List<TaskView> getReadyTasks();
+    List<TaskView> getReadyTaskViews();
 
     /**
      * Returns a list of all suspended tasks.
      * All these tasks wait on a guard.
      * Some of these guards may be true.
      */
-    List<TaskView> getSuspendedTasks();
+    List<TaskView> getSuspendedTaskViews();
 
     /**
      * Returns a list of schedulable tasks.
      * This list contains all tasks of getReadyTasks() plus the tasks
      * from getSuspendedTasks(), which are waiting on a guard which is true
      */
-    List<TaskView> getSchedulableTasks();
+    List<TaskView> getSchedulableTaskViews();
     
-    TaskView getActiveTask();
+    TaskView getActiveTaskView();
 
     void registerTaskSchedulerObserver(TaskSchedulerObserver listener);
 

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/TaskStackFrameView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/TaskStackFrameView.java
@@ -19,7 +19,7 @@ public interface TaskStackFrameView {
      * Returns the stack to which this frame belongs to
      * @return the stack to which this frame belongs to
      */
-    public TaskStackView getStack();
+    public TaskStackView getStackView();
     
     /**
      * Returns all variable names of this stack frame
@@ -38,6 +38,6 @@ public interface TaskStackFrameView {
      * Returns the method of this stack frame
      * @return the method of this stack frame
      */
-    public MethodView getMethod();
+    public MethodView getMethodView();
 
 }

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/TaskStackView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/TaskStackView.java
@@ -23,14 +23,14 @@ public interface TaskStackView {
      * Returns the task to which this stack belongs to
      * @return the task to which this stack belongs to
      */
-    public TaskView getTask();
+    public TaskView getTaskView();
     
     /**
      * Returns the list of stack frames of this task stack.
      * The last element of the list represents the top of the stack
      * @return the list of stack frames of this task stack.
      */
-    public List<? extends TaskStackFrameView> getFrames();
+    public List<? extends TaskStackFrameView> getFrameViews();
     
     /**
      * Returns the current active frame of the task stack.
@@ -38,7 +38,7 @@ public interface TaskStackView {
      * Returns null if there is no stack frame
      * @return the current active frame of the task stack, or null if there is no frame 
      */
-    public TaskStackFrameView getCurrentFrame();
+    public TaskStackFrameView getCurrentFrameView();
 
     /**
      * Whether this task has any frames

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/TaskView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/TaskView.java
@@ -15,7 +15,7 @@ public interface TaskView {
      * 
      * @return the calling task
      */
-    TaskView getSender();
+    TaskView getSenderView();
 
     /**
      * The source object of the asynchronous call leading to this task is null
@@ -23,17 +23,17 @@ public interface TaskView {
      * 
      * @return the source object, or <code>null</code> if there is no source object
      */
-    ObjectView getSource();
+    ObjectView getSourceObjectView();
 
-    ObjectView getTarget();
+    ObjectView getTargetObjectView();
 
-    COGView getCOG();
+    COGView getCOGView();
 
     String getMethodName();
 
     List<Object> getArgs();
 
-    FutView getFuture();
+    FutView getFutView();
 
     void registerTaskListener(TaskObserver listener);
 
@@ -44,6 +44,6 @@ public interface TaskView {
     boolean hasException();
 
     ABSException getException();
-    
-    TaskStackView getStack();
+
+    TaskStackView getStackView();
 }

--- a/frontend/src/main/java/org/abs_models/backend/java/scheduling/DefaultTaskScheduler.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/scheduling/DefaultTaskScheduler.java
@@ -217,31 +217,35 @@ public class DefaultTaskScheduler implements TaskScheduler {
     }
 
     @Override
-    public synchronized TaskSchedulerView getView() {
+    public TaskSchedulerView getView() {
         if (view == null) {
-            view = new View();
+            synchronized(this) {
+                if (view == null) {
+                    view = new View();
+                }
+            }
         }
         return view;
     }
 
     private class View extends AbstractTaskSchedulerView {
         @Override
-        public List<TaskView> getReadyTasks() {
+        public List<TaskView> getReadyTaskViews() {
             return null;
         }
 
         @Override
-        public List<TaskView> getSuspendedTasks() {
+        public List<TaskView> getSuspendedTaskViews() {
             return null;
         }
 
         @Override
-        public List<TaskView> getSchedulableTasks() {
+        public List<TaskView> getSchedulableTaskViews() {
             return null;
         }
 
         @Override
-        public TaskView getActiveTask() {
+        public TaskView getActiveTaskView() {
             return DefaultTaskScheduler.this.getActiveTask().getView();
         }
 

--- a/frontend/src/main/java/org/abs_models/backend/java/scheduling/SimpleTaskScheduler.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/scheduling/SimpleTaskScheduler.java
@@ -402,15 +402,15 @@ public class SimpleTaskScheduler implements TaskScheduler {
 
     private volatile View view;
 
-    private final Object viewCreatorLock = new Object();
-
     @Override
     public TaskSchedulerView getView() {
-        synchronized (viewCreatorLock) {
-        if (view == null)
-            view = new View();
-        return view;
+        if (view == null) {
+            synchronized(this) {
+                if (view == null)
+                    view = new View();
+            }
         }
+        return view;
     }
 
     @Override
@@ -490,11 +490,11 @@ public class SimpleTaskScheduler implements TaskScheduler {
     private class View extends AbstractTaskSchedulerView {
 
         @Override
-        public List<TaskView> getSchedulableTasks() {
+        public List<TaskView> getSchedulableTaskViews() {
             synchronized (SimpleTaskScheduler.this) {
                 ArrayList<TaskView> result = new ArrayList<>();
                 if (getActiveTask() != null) {
-                    result.add(getActiveTask());
+                    result.add(getActiveTaskView());
                     return result;
                 }
 
@@ -507,7 +507,7 @@ public class SimpleTaskScheduler implements TaskScheduler {
         }
 
         @Override
-        public List<TaskView> getReadyTasks() {
+        public List<TaskView> getReadyTaskViews() {
             synchronized (SimpleTaskScheduler.this) {
                 ArrayList<TaskView> result = new ArrayList<>();
                 for (TaskInfo t : readyTasks) {
@@ -519,7 +519,7 @@ public class SimpleTaskScheduler implements TaskScheduler {
         }
 
         @Override
-        public List<TaskView> getSuspendedTasks() {
+        public List<TaskView> getSuspendedTaskViews() {
             synchronized (SimpleTaskScheduler.this) {
                 ArrayList<TaskView> result = new ArrayList<>();
                 for (TaskInfo t : suspendedTasks) {
@@ -531,7 +531,7 @@ public class SimpleTaskScheduler implements TaskScheduler {
         }
 
         @Override
-        public TaskView getActiveTask() {
+        public TaskView getActiveTaskView() {
             Task<?> activeTask = SimpleTaskScheduler.this.getActiveTask();
             if (activeTask == null)
                 return null;

--- a/frontend/src/main/java/org/abs_models/backend/java/visualization/SequenceDiagramVisualization.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/visualization/SequenceDiagramVisualization.java
@@ -63,7 +63,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
         String className = initialObject.getClassName();
         createdCOGClasses.put(cog,className);
         if (isObservedClass(className)) {
-            cog.getScheduler().registerTaskSchedulerObserver(this);
+            cog.getSchedulerView().registerTaskSchedulerObserver(this);
             if (!staticActors) {
                 if (!firstMessage) {
                     // special support for adding nodes later to a diagram
@@ -99,7 +99,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
 
 
     protected synchronized Integer getID(ObjectView v) {
-        Integer id = objectIds.get(v.getCOG());
+        Integer id = objectIds.get(v.getCOGView());
         if (id == null) {
             AtomicInteger counter = idCounters.get(v.getClassName());
             if (counter == null) {
@@ -107,7 +107,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
                 idCounters.put(v.getClassName(), counter);
             }
             id = counter.incrementAndGet();
-            objectIds.put(v.getCOG(), id);
+            objectIds.put(v.getCOGView(), id);
         }
         return id;
     }
@@ -171,7 +171,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
                 if (!isObserved(task))
                     return;
                 waitingFutures.add(fut);
-                String actorName = getActorName(task.getTarget());
+                String actorName = getActorName(task.getTargetObjectView());
                 writeOutLn("*" + fut.getID() + " " + actorName);
                 writeOutLn("future get");
                 writeOutLn("*" + fut.getID());
@@ -189,9 +189,9 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
                     return;
                 resolvedFutures.add(fut);
 
-                TaskView futTask = fut.getResolvingTask();
-                String sourceClass = futTask.getTarget().getClassName();
-                writeOut(getActorName(futTask.getTarget()));
+                TaskView futTask = fut.getResolvingTaskView();
+                String sourceClass = futTask.getTargetObjectView().getClassName();
+                writeOut(getActorName(futTask.getTargetObjectView()));
                 if (isSystemClass(sourceClass)) {
                     //if (futTask.getID() != 1) // no main task
                         writeOut("[" + "Task" + futTask.getID() + "]");
@@ -199,12 +199,12 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
                 } else {
                     writeOut(":");
                 }
-                String futTaskName = getActorName(task.getTarget()) + "[" + "FutTask" + futTask.getID() + "]";
+                String futTaskName = getActorName(task.getTargetObjectView()) + "[" + "FutTask" + futTask.getID() + "]";
                 writeOut(futTaskName);
                 writeOutLn(".future resolved\\:" + shorten(String.valueOf(fut.getValue())));
                 writeOutLn(futTaskName + ":stop");
-                writeOutLn("(" + fut.getID() + ") " + getActorName(task.getTarget()));
-                writeOutLn(getActorName(futTask.getTarget())+ "[Task" + futTask.getID() + "]:stop");
+                writeOutLn("(" + fut.getID() + ") " + getActorName(task.getTargetObjectView()));
+                writeOutLn(getActorName(futTask.getTargetObjectView())+ "[Task" + futTask.getID() + "]:stop");
             }
         }
 
@@ -214,12 +214,12 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
     public synchronized void taskCreated(TaskView task) {
         task.registerTaskListener(this);
 
-        if (task.getSource() == null) {
+        if (task.getSourceObjectView() == null) {
             return;
         }
 
-        String sourceClass = getClassName(task.getSource());
-        String targetClass = getClassName(task.getTarget());
+        String sourceClass = getClassName(task.getSourceObjectView());
+        String targetClass = getClassName(task.getTargetObjectView());
 
         if (isObservedClass(sourceClass) && isObservedClass(targetClass)) {
 
@@ -228,9 +228,9 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
             if (isEnvironmentClass(sourceClass) || isEnvironmentClass(targetClass))
                 msgAction = ":";
 
-            String source = getActorName(task.getSource());
+            String source = getActorName(task.getSourceObjectView());
             if (isSystemClass(sourceClass))
-                source = source + "[" + "Task" + task.getSender().getID() + "]";
+                source = source + "[" + "Task" + task.getSenderView().getID() + "]";
 
             if (firstMessage) {
                 writeOutLn();
@@ -249,7 +249,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
              * if (systemClasses.contains(task.getSource().getClassName())) {
              * writeOut(":>"); }
              */
-            writeOut(getActorName(task.getTarget()));
+            writeOut(getActorName(task.getTargetObjectView()));
             if (isSystemClass(targetClass)) {
                 //if (task.getID() != 1) // no main task
                     writeOut("[" + "Task" + task.getID() + "]");
@@ -278,7 +278,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
     }
 
     private String getClassName(ObjectView obj) {
-        return createdCOGClasses.get(obj.getCOG());
+        return createdCOGClasses.get(obj.getCOGView());
     }
 
     private String shorten(String arg) {
@@ -305,13 +305,13 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
             return;
         // writeOut("Future " + task.getFuture().getID() + " resolved\\: " +
         // task.getFuture().getValue());
-        if (!waitingFutures.contains(task.getFuture())) {
-            String taskName = getActorName(task.getTarget());
+        if (!waitingFutures.contains(task.getFutView())) {
+            String taskName = getActorName(task.getTargetObjectView());
             //if (task.getID() != 1) // no main task
                 taskName += "[" + "Task" + task.getID() + "]";
             writeOutLn(taskName + ":"); // do something to avoid empty tasks
             writeOutLn(taskName + ":stop");
-            resolvedFutures.add(task.getFuture());
+            resolvedFutures.add(task.getFutView());
         }
     }
 
@@ -319,7 +319,7 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
     public synchronized void taskStarted(TaskView task) {
         if (!isObserved(task))
             return;
-        String target = task.getTarget().getClassName();
+        String target = task.getTargetObjectView().getClassName();
         // writeOut(target+"[" + "Task" + task.getID() + "]:<started>"); //
         // do something to avoid empty tasks
 
@@ -331,10 +331,10 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
             return;
 
         if (guard.isFutureGuard()) {
-            FutView fut = guard.getFuture();
-            if (isObserved(fut.getResolvingTask())) {
+            FutView fut = guard.getFutView();
+            if (isObserved(fut.getResolvingTaskView())) {
                 waitingFutures.add(fut);
-                String actorName = getActorName(task.getTarget());
+                String actorName = getActorName(task.getTargetObjectView());
                 writeOutLn("*" + fut.getID() + " " + actorName);
                 // writeOut("[" + "Task" + task.getID() + "]");
                 // writeOut(":");
@@ -352,8 +352,8 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
     }
 
     public boolean isObserved(TaskView task) {
-        String source = task.getSource().getClassName();
-        String target = task.getTarget().getClassName();
+        String source = task.getSourceObjectView().getClassName();
+        String target = task.getTargetObjectView().getClassName();
         return isObservedClass(source) && isObservedClass(target)
                 && isSystemClass(target);
     }
@@ -367,32 +367,32 @@ public class SequenceDiagramVisualization implements SystemObserver, TaskObserve
         if (!isObserved(task))
             return;
         if (guard.isFutureGuard()) {
-            FutView fut = guard.getFuture();
+            FutView fut = guard.getFutView();
 
-            TaskView resolvingTask = fut.getResolvingTask();
+            TaskView resolvingTask = fut.getResolvingTaskView();
             if (isObserved(resolvingTask)) {
 
                 if (!waitingFutures.contains(fut) || resolvedFutures.contains(fut))
                     return;
                 resolvedFutures.add(fut);
 
-                writeOut(getActorName(resolvingTask.getTarget()));
+                writeOut(getActorName(resolvingTask.getTargetObjectView()));
                 writeOut("[" + "Task" + resolvingTask.getID() + "]");
                 writeOut(":>");
-                writeOut(getActorName(task.getTarget()));
+                writeOut(getActorName(task.getTargetObjectView()));
                 writeOut("[" + "Taskx" + resolvingTask.getID() + "]");
                 writeOut(".resolved\\: ");
                 writeOut(shorten(String.valueOf(fut.getValue())));
                 writeOutLn();
-                writeOut(getActorName(resolvingTask.getTarget()));
+                writeOut(getActorName(resolvingTask.getTargetObjectView()));
                 writeOut("[" + "Task" + resolvingTask.getID() + "]");
                 writeOut(":stop");
                 writeOutLn();
-                writeOut(getActorName(task.getTarget()));
+                writeOut(getActorName(task.getTargetObjectView()));
                 writeOut("[" + "Taskx" + resolvingTask.getID() + "]");
                 writeOut(":stop");
                 writeOutLn();
-                writeOutLn("(" + fut.getID() + ") " + getActorName(task.getTarget()));
+                writeOutLn("(" + fut.getID() + ") " + getActorName(task.getTargetObjectView()));
             }
         }
     }

--- a/frontend/src/main/java/org/abs_models/backend/java/visualization/TaskStateHistoryObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/visualization/TaskStateHistoryObserver.java
@@ -48,7 +48,7 @@ public class TaskStateHistoryObserver implements SystemObserver,TaskSchedulerObs
 
     @Override
     public void newCOGCreated(COGView cog, ObjectView initialObject) {
-        cog.getScheduler().registerTaskSchedulerObserver(this);
+        cog.getSchedulerView().registerTaskSchedulerObserver(this);
     }
 
     @Override

--- a/frontend/src/test/java/org/abs_models/backend/java/RuntimeUsageTest.java
+++ b/frontend/src/test/java/org/abs_models/backend/java/RuntimeUsageTest.java
@@ -92,7 +92,7 @@ public class RuntimeUsageTest implements SystemObserver, ObjectCreationObserver,
         System.out.println(name+": created cog "+cog.getID());
         objectCreated(initialObject);
         cog.registerObjectCreationListener(this);
-        cog.getScheduler().registerTaskSchedulerObserver(this);
+        cog.getSchedulerView().registerTaskSchedulerObserver(this);
     }
 
     @Override
@@ -173,7 +173,7 @@ public class RuntimeUsageTest implements SystemObserver, ObjectCreationObserver,
 
     @Override
     public void localVariableChanged(TaskStackFrameView stackFrame, String n, Object v) {
-        System.out.println(name+":task "+stackFrame.getStack().getTask().getID()+": local variable "+n+" = "+v);
+        System.out.println(name+":task "+stackFrame.getStackView().getTaskView().getID()+": local variable "+n+" = "+v);
         
     }
 

--- a/frontend/src/test/java/org/abs_models/backend/java/TestSystemObserver.java
+++ b/frontend/src/test/java/org/abs_models/backend/java/TestSystemObserver.java
@@ -19,7 +19,7 @@ public class TestSystemObserver implements SystemObserver, ObjectCreationObserve
         System.out.println("NEW COG CREATED");
         COGView mainCOG = cog;
         mainCOG.registerObjectCreationListener(this);
-        mainCOG.getScheduler().registerTaskSchedulerObserver(new TaskSchedulerObserver() {
+        mainCOG.getSchedulerView().registerTaskSchedulerObserver(new TaskSchedulerObserver() {
             TaskView mainTask;
 
             @Override
@@ -35,9 +35,9 @@ public class TestSystemObserver implements SystemObserver, ObjectCreationObserve
                     });
                 }
                 String sourceClass = "INIT";
-                if (task.getSource() != null)
-                    sourceClass = task.getSource().getClassName();
-                System.out.print("TASK CREATED: " + sourceClass + " --> " + task.getTarget().getClassName() + "."
+                if (task.getSourceObjectView() != null)
+                    sourceClass = task.getSourceObjectView().getClassName();
+                System.out.print("TASK CREATED: " + sourceClass + " --> " + task.getTargetObjectView().getClassName() + "."
                         + task.getMethodName() + "(");
                 int i = 0;
                 for (Object v : task.getArgs()) {


### PR DESCRIPTION
A lot of the Java backend runtime objects have an associated "view" that is created on-demand.  These views are used to introspect model state at runtime, including registering observers that are called when certain events occur (object creation, task scheduling, etc.)

- Make sure all views are created in a safe way via the double null-check idiom, instead of using volatile variables / always locking on a separate object / no protection at al / etc.

- Rename methods on views to make it obvious that views are returned: instead of `getCOG` use `getCOGView` etc.