### PR TITLE
Implement semantic lifting of runtime state in the Java backend

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -60,10 +60,13 @@ dependencies {
     implementation 'org.apfloat:apfloat:1.14.0'
     // SQLite library for the Java backend
     implementation 'org.xerial:sqlite-jdbc:3.50.2.0'
-    // // Logging backend used by SQLite library
-    // implementation 'org.slf4j:slf4j-jdk14:2.0.16'
+    // Adding a logging backend so Jena doesn't complain
+    implementation 'org.slf4j:slf4j-jdk14:2.0.16'
     // JSON library for the Java backend Model API
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.1'
+
+    // Apache Jena, for semantic querying in the Java backend
+    implementation 'org.apache.jena:apache-jena-libs:5.4.0'
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
@@ -202,7 +205,7 @@ jar {
 }
 
 shadowJar {
-    
+    mergeServiceFiles() // https://jena.apache.org/documentation/notes/jena-repack.html
 }
 
 // this is necessary for the `absc` scripts

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicObject.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSDynamicObject.java
@@ -111,6 +111,7 @@ public class ABSDynamicObject extends ABSObject {
     }
 
 
+    private final  View __dynamicView = new View();
 
     public ObjectView getView() {
         if (view == null) {
@@ -153,6 +154,11 @@ public class ABSDynamicObject extends ABSObject {
         @Override
         public long getID() {
             return ABSDynamicObject.this.__id;
+        }
+
+        @Override
+        public ABSObject getObject() {
+            return ABSDynamicObject.this;
         }
 
         @Override

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
@@ -132,6 +132,11 @@ public abstract class ABSObject implements ABSRef {
         }
 
         @Override
+        public ABSObject getObject() {
+            return ABSObject.this;
+        }
+
+        @Override
         public String getName() {
             return getClassName();
         }

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/COG.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/COG.java
@@ -176,31 +176,26 @@ public class COG {
     }
 
     private class View implements COGView {
-        private List<ObjectCreationObserver> creationListeners;
-        private Map<String, List<ObjectCreationObserver>> creationClassListeners;
+        private List<ObjectCreationObserver> creationListeners = new ArrayList<>();
+        private Map<String, List<ObjectCreationObserver>> creationClassListeners = new HashMap<>();
 
         synchronized void notifyListeners(ABSObject absObject, boolean created) {
-            if (creationListeners != null) {
-                for (ObjectCreationObserver l : creationListeners) {
+            for (ObjectCreationObserver l : creationListeners) {
+                if (created)
+                    l.objectCreated(absObject.getView());
+                else
+                    l.objectInitialized(absObject.getView());
+            }
+
+            List<ObjectCreationObserver> list = creationClassListeners.get(absObject.getClassName());
+            if (list != null) {
+                for (ObjectCreationObserver l : list) {
                     if (created)
                         l.objectCreated(absObject.getView());
                     else
                         l.objectInitialized(absObject.getView());
                 }
             }
-
-            if (creationClassListeners != null) {
-                List<ObjectCreationObserver> list = creationClassListeners.get(absObject.getClassName());
-                if (list != null) {
-                    for (ObjectCreationObserver l : list) {
-                        if (created)
-                            l.objectCreated(absObject.getView());
-                        else
-                            l.objectInitialized(absObject.getView());
-                    }
-                }
-            }
-
         }
 
         synchronized void objectCreated(ABSObject absObject) {
@@ -213,18 +208,11 @@ public class COG {
 
         @Override
         public synchronized void registerObjectCreationListener(ObjectCreationObserver listener) {
-            if (creationListeners == null) {
-                creationListeners = new ArrayList<>(1);
-            }
             creationListeners.add(listener);
         }
 
         @Override
         public synchronized void registerObjectCreationListener(String className, ObjectCreationObserver e) {
-            if (creationClassListeners == null) {
-                creationClassListeners = new HashMap<>();
-            }
-
             List<ObjectCreationObserver> list
                 = creationClassListeners.computeIfAbsent(className, k -> new ArrayList<>(1));
             list.add(e);

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/RuntimeOptions.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/RuntimeOptions.java
@@ -216,6 +216,10 @@ public class RuntimeOptions {
         addOption(CLASS, "schedulableTasksFilter", "--schedulableTasksFilter", "sets a filter class for schedulable tasks", null);
     public final Option dynamicUpdates =
         addOption(BOOLEAN, "dynamic", "--dynamic", "enables dynamic program updates (not supported)", false);
+    public final Option printRDF =
+        addOption(BOOLEAN, "printRDF", "--printRDF", "Show program state as RDF after model finishes", false);
+    public final Option sparqlQuery =
+        addOption(STRING, "sparqlQuery", "--sparqlQuery", "Run SPARQL query on RDF program state after model finishes", null);
 
     public RuntimeOptions(String[] args) {
         evaluateSystemProperties();

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/StartUp.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/StartUp.java
@@ -5,12 +5,16 @@
 package org.abs_models.backend.java.lib.runtime;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.abs_models.backend.java.lib.net.ABSNetRuntime;
 import org.abs_models.backend.java.lib.net.NetworkImpl;
 import org.abs_models.backend.java.lib.net.NodeImpl;
 import org.abs_models.backend.java.observing.DefaultSystemObserver;
+import org.abs_models.backend.java.observing.GraphObserver;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.rdf.model.Model;
 
 public class StartUp {
     public static void startup(String[] args, Class<?> mainClass) throws InstantiationException, IllegalAccessException, IOException, InterruptedException {
@@ -27,14 +31,37 @@ public class StartUp {
         } else {
             runtime = ABSRuntime.getRuntime();
         }
+        final boolean useRDF = options.printRDF.isTrue() || options.sparqlQuery.wasSet();
         ABSRuntime.setRunsInOwnProcess(true);
         Config.initRuntimeFromOptions(runtime, options);
         runtime.addSystemObserver(new DefaultSystemObserver() {
             public void systemFinished() {
+                // Avoid garbage collection of objects, cogs after
+                // model is finished
+                if (useRDF) GraphObserver.freezeObserver();
                 latch.countDown();
             }
         });
+        if (useRDF) {
+            runtime.addSystemObserver(new GraphObserver());
+        }
         runtime.start(mainClass);
         latch.await();
+
+        if (useRDF) {
+            Model model = GraphObserver.getModel();
+            if (options.printRDF.isTrue()) GraphObserver.printGraph(model);
+            if (options.sparqlQuery.wasSet()) {
+                List<QuerySolution> results = GraphObserver.runQuery(model,
+                    options.sparqlQuery.stringValue());
+                // SELECT ?cog WHERE { ?obj abs:in ?cog }
+                results.forEach((solution) -> {
+                    System.out.println(solution);
+                    // solution.varNames().forEachRemaining((String varName) -> {
+                    //     System.out.println("Var " + varName + " is bound to " + solution.get(varName));
+                    // });
+                });
+            }
+        }
     }
 }

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
@@ -1,0 +1,195 @@
+package org.abs_models.backend.java.observing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import org.abs_models.backend.java.lib.runtime.ABSObject;
+import org.abs_models.backend.java.lib.runtime.COG;
+import org.abs_models.backend.java.lib.types.ABSAlgebraicDataType;
+import org.abs_models.backend.java.lib.types.ABSInterface;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apfloat.Apint;
+import org.apfloat.Aprational;
+
+/**
+ * An observer that follows cog (and, transitively, object) creation.
+ * It is used to create an object graph upon request.
+ */
+public class GraphObserver extends DefaultSystemObserver implements ObjectCreationObserver {
+
+    /** The abs language ontology prefix */
+    static String absNS = "http://abs-models.org/ns/abs/";
+    /** The program ontology prefix */
+    static String progNS = "http://abs-models.org/ns/prog/";
+    /** The runtime ontology prefix */
+    static String runNS = "http://abs-models.org/ns/run/";
+
+    static String sparqlPrefix = "PREFIX abs: <" + absNS + ">\n"
+                               + "PREFIX prog: <" + progNS + ">\n"
+                               + "PREFIX run: <" + runNS + ">\n";
+
+    // Note: iterate over the sets below using a snapshot to avoid gc
+    // messing with us: `for (Object obj : Set.copyOf(objectSet)) { }`
+    private static Set<ObjectView> objectSet = Collections.newSetFromMap(new WeakHashMap<ObjectView, Boolean>());
+    private static Set<COGView> cogSet = Collections.newSetFromMap(new WeakHashMap<COGView, Boolean>());
+
+    /**
+     * Deactivate garbage collection of registered objects and sets.
+     * Should be done at the end of the model run so the end state is
+     * preserved.
+     */
+    public static synchronized void freezeObserver() {
+        objectSet = Set.copyOf(objectSet);
+        cogSet = Set.copyOf(cogSet);
+    }
+
+    /**
+     * Note an object to be added to the object graph.
+     */
+    public static synchronized void addObject(ObjectView o) {
+        objectSet.add(o);
+    }
+
+    /**
+     * Note a cog to be added to the object graph.
+     */
+    public static synchronized void addCog(COGView c) {
+        cogSet.add(c);
+    }
+
+    @Override
+    public void newCOGCreated(COGView cog, ObjectView initialObject) {
+        cog.registerObjectCreationListener(this);
+        cogSet.add(cog);
+        this.objectCreated(initialObject);
+    }
+
+    @Override
+    public void objectCreated(ObjectView o) {
+        addObject(o);
+    }
+
+    @Override
+    public void objectInitialized(ObjectView o) { }
+
+    /**
+     * Run a SPARQL query over the current ABS state.  The {@code
+     * abs:}, {@code prog:} and {@code run:} namespaces are added to
+     * the query string, so do not need to be defined.
+     */
+    public static List<QuerySolution> runQuery(Model model, String queryString) {
+        List<QuerySolution> result = new ArrayList<>();
+        queryString = sparqlPrefix + queryString;
+        Query query = QueryFactory.create(queryString);
+        try (QueryExecution qexec = QueryExecutionFactory.create(query, model)) {
+            ResultSet results = qexec.execSelect();
+            results.forEachRemaining((solution) -> {
+                result.add(solution);
+            });
+            return result;
+        }
+    }
+
+    /**
+     * Print an RDF graph of the current ABS state, in TRTL format.
+     */
+    public static void printGraph(Model model) {
+        model.write(System.out, "TURTLE");
+    }
+
+    /**
+     * Return an RDF model of the current ABS state.
+     */
+    public static Model getModel() {
+        Model model = ModelFactory.createDefaultModel();
+        model.setNsPrefix("abs", absNS);
+        model.setNsPrefix("prog", progNS);
+        model.setNsPrefix("run", runNS);
+        Set<ObjectView> objects = Set.copyOf(objectSet);
+        Set<COGView> cogs = Set.copyOf(cogSet);
+        for (ObjectView view : objects) {
+            addObjectTriples(model, view);
+        }
+        for (COGView view : cogs) {
+            addCogTriples(model, view);
+        }
+        return model;
+    }
+
+    public static void addCogTriples(Model model, COGView view) {
+        COG cog = view.getCOG();
+        ABSInterface dc = cog.getDC();
+        Resource cogRes = model.createResource(runNS + "cog" + cog.hashCode(),
+            model.createResource(absNS + "cog"));
+        Property inProp = model.createProperty(absNS + "in");
+        cogRes.addProperty(inProp, model.createResource(runNS + "obj" + dc.hashCode()));
+    }
+
+    /**
+     * Add all triples defining the given object to the model.
+     */
+    static void addObjectTriples(Model model, ObjectView view) {
+        ABSObject obj = view.getObject();
+        String type = obj.getClass().getPackageName() + "." + obj.getClassName();
+        Resource objRes = model.createResource(runNS + "obj" + obj.hashCode(),
+            model.createResource(progNS + type));
+        Property inProp = model.createProperty(absNS + "in");
+        objRes.addProperty(inProp, model.createResource(runNS + "cog" + obj.getCOG().hashCode()));
+        for (String fieldName : obj.getFieldNames()) {
+            Property fieldProp = model.createProperty(progNS + fieldName);
+            try {
+                addFieldTriples(model, objRes, fieldProp, obj.getView().getFieldValue(fieldName));
+			} catch (NoSuchFieldException e) {
+                continue;
+                // should never happen
+			}
+        }
+    }
+
+    static void addFieldTriples(Model model, Resource res, Property fieldProp, Object value) {
+        switch (value) {
+            case null:
+                res.addLiteral(fieldProp, model.createTypedLiteral("null"));
+                break;
+            case Apint i:
+                res.addLiteral(fieldProp, model.createTypedLiteral(i.toBigInteger()));
+                break;
+            case Aprational r:
+                res.addLiteral(fieldProp, model.createTypedLiteral(r.doubleValue()));
+                break;
+            case ABSObject o2:
+                res.addProperty(fieldProp, model.createResource(runNS + "obj" + o2.hashCode()));
+                break;
+            case ABSAlgebraicDataType a:
+                Resource r = addDataValueTriples(model, a);
+                res.addProperty(fieldProp, r);
+                break;
+            default:
+                res.addLiteral(fieldProp, model.createTypedLiteral(value));
+        }
+    }
+
+    static Resource addDataValueTriples(Model model, ABSAlgebraicDataType a) {
+        String type = a.getClass().getPackageName() + "." + a.getConstructorName();
+        Resource result = model.createResource(model.createResource(progNS + type));
+        for (int i = 0; i < a.getNumArgs(); i++) {
+            Property prop = model.createProperty(progNS + "arg" + i);
+            Object value = a.getArg(i);
+            addFieldTriples(model, result, prop, value);
+        }
+        return result;
+    }
+
+}

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectCreationObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectCreationObserver.java
@@ -6,8 +6,13 @@ package org.abs_models.backend.java.observing;
 
 public interface ObjectCreationObserver {
     /**
-     * Is called after an object has been created, but before
-     * it has been initialized
+     * This method is called after an object has been created, but
+     * before it has been initialized.
+     *
+     * <p>Note that this method is not called for the first object of
+     * a cog; instead, the first object is passed as the second
+     * parameter of {@link SystemObserver#newCOGCreated}.
+     *
      * @param o the object that was created
      */
     void objectCreated(ObjectView o);

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectView.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/ObjectView.java
@@ -6,6 +6,8 @@ package org.abs_models.backend.java.observing;
 
 import java.util.List;
 
+import org.abs_models.backend.java.lib.runtime.ABSObject;
+
 public interface ObjectView {
     COGView getCOGView();
 
@@ -20,4 +22,6 @@ public interface ObjectView {
     List<String> getFieldNames();
 
     long getID();
+
+    ABSObject getObject();
 }


### PR DESCRIPTION
Note that the ontologies for the abs language and program are not included in this commit, so reasoning support is sparse.

- Add GraphObserver that keeps track of created objects via a weak hash table

- New runtime option: `--printRDF` dumps the program state after the model finishes.

- New runtime option: `--sparqlQuery` executes the given query on the program state after the model finishes.