### PR TITLE
2.1.2 query via POST with URL-encoded parameters

### DIFF
--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ModelApi.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ModelApi.java
@@ -202,7 +202,6 @@ public class ModelApi {
                 exchange.close();
                 return;
             }
-            log.severe(queryString);
             Lang lang = negotiateContentType(exchange.getRequestHeaders().getFirst("Accept"));
             String solution = GraphObserver.runQuery(GraphObserver.getModel(), queryString, lang);
             sendResponse(exchange, 200, lang.getHeaderString(), solution);


### PR DESCRIPTION
Implementing [url-encoded post requests](https://www.w3.org/TR/sparql11-protocol/#query-via-post-urlencoded) for the sparql endpoint. We are still missing the optional default and named graph URIs.