### PR TITLE
Query sparql within a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     SPARQL query will run and print the result of the query after the
     model has finished.
   - The Model API offers an additional URL `/sparql` that implements a
-    SPARQL endpoint.
+    SPARQL endpoint as specified in Section 2.1 of
+    <https://www.w3.org/TR/sparql11-protocol/>.
+
+- In the Java backend, it is now possible to define functions that
+  query the lifted program state, for example, to find objects that
+  implement an interface `Test.I`:
+
+  ```
+  def List<I> find_objects() = builtin(sparql, 
+    `SELECT ?o WHERE {
+       ?o a/abs:implements/rdfs:label "Test.I" .
+     }`)
+  ```
+
+  See the manual for more details.  Note that this querying facility
+  is provisional and its semantics might change.
 
 - A new function `range(a, b)` in the standard library returns a list
   of integers ranging from a to b (inclusive).  This is useful, for

--- a/frontend/src/main/java/org/abs_models/backend/java/codegeneration/GenerateJava.jadd
+++ b/frontend/src/main/java/org/abs_models/backend/java/codegeneration/GenerateJava.jadd
@@ -216,7 +216,7 @@ aspect GenerateJava {
             // - SQLite queries; for these, we need to generate a body that
             //   runs the query.
             BuiltinFunctionDef b = (BuiltinFunctionDef)getFunctionDef();
-            if (!b.isSQLite3Query()) {
+            if (!b.isSQLite3Query() && !b.isSparqlQuery()) {
                 return;
             }
         }
@@ -234,8 +234,8 @@ aspect GenerateJava {
         JavaGeneratorHelper.generateParams(stream, getParams(), true);
         stream.println(" {");
         if (getFunctionDef() instanceof BuiltinFunctionDef) {
-            // Can currently only be an SQLite query; let it emit a function
-            // body instead of a single expression.
+            // Can currently only be an SQLite or Sparql query; let it
+            // emit a function body instead of a single expression.
             getFunctionDef().generateJava(stream);
         } else if (getFunctionDef() instanceof ExpFunctionDef) {
             Set<PatternVarUse> boundVars = ((ExpFunctionDef)getFunctionDef()).getRhs().boundPatternVars();
@@ -271,6 +271,8 @@ aspect GenerateJava {
         // including a return statement instead of just an expression.
         if (isSQLite3Query()) {
             JavaGeneratorHelper.generateSqlite3Body(stream, this);
+        } else if (isSparqlQuery()) {
+            JavaGeneratorHelper.generateSparqlBody(stream, this);
         } else {
             stream.println("return null;");
         }

--- a/frontend/src/main/java/org/abs_models/backend/java/codegeneration/JavaGeneratorHelper.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/codegeneration/JavaGeneratorHelper.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -19,6 +17,7 @@ import java.util.stream.StreamSupport;
 
 import org.abs_models.backend.java.JavaBackend;
 import org.abs_models.backend.java.JavaBackendConstants;
+import org.abs_models.backend.java.JavaBackendException;
 import org.abs_models.backend.java.lib.expr.BinOp;
 import org.abs_models.backend.java.lib.runtime.ABSBuiltInFunctions;
 import org.abs_models.backend.java.lib.runtime.ABSFut;
@@ -69,11 +68,9 @@ import org.abs_models.frontend.ast.VarDecl;
 import org.abs_models.frontend.ast.VarOrFieldDecl;
 import org.abs_models.frontend.ast.VarUse;
 import org.abs_models.frontend.typechecker.DataTypeType;
+import org.abs_models.frontend.typechecker.InterfaceType;
 import org.abs_models.frontend.typechecker.Type;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apfloat.Apint;
 import org.apfloat.Aprational;
@@ -333,6 +330,73 @@ public class JavaGeneratorHelper {
         stream.println("} catch (java.sql.SQLException e) {");
         stream.println("System.err.println(e);");
         stream.println("System.exit(1);");
+        stream.println("}");
+        stream.println("for (Object row : acc) {");
+        stream.println("result = new ABS.StdLib.List_Cons(row, result);");
+        stream.println("}");
+        stream.println("return result;");
+    }
+
+    /**
+     * Generate function body for Sparql query functions.  Those are
+     * functions defined as {@code builtin(sparql, ...)} -- see the
+     * language manual for details.
+     */
+    public static void generateSparqlBody(PrintStream stream, BuiltinFunctionDef body) {
+
+        String query = (GraphObserver.sparqlPrefix + ((StringLiteral)body.getArgument(1)).getContent())
+            .replaceAll("[\r\n]+\\s*", " ")
+            .replace("\"", "\\\"");
+        FunctionDecl decl = body.closestParent(FunctionDecl.class);
+        // Type checking ensures that decl has a type `List<X>'; get the X
+        // TODO: currently we assume String
+        Type query_type = ((DataTypeType)decl.getType()).getTypeArg(0);
+
+        String obs = GraphObserver.class.getName();
+
+        stream.println("java.util.List<Object> acc = new java.util.ArrayList<>();");
+        stream.println("ABS.StdLib.List result = new ABS.StdLib.List_Nil();");
+        stream.println("var solutions = " + obs + ".runQuery(" + obs + ".getModel(), \"" + query + "\");");
+        stream.println("for (var solution : solutions) {");
+        if (query_type.isIntType() || query_type.isFloatType() || query_type.isStringType() || query_type.isBoolType() || query_type.isRatType()) {
+            // handle singleton literal return value
+            stream.println("String varName = solution.varNames().next();");
+            stream.println("var o = solution.get(varName);");
+            stream.println("if (o.isLiteral()) {");
+            stream.println("var l = o.asLiteral();");
+            stream.print("acc.add(0, ");
+            if (query_type.isBoolType()) {
+                stream.print("l.getBoolean()");
+            } else if (query_type.isIntType()) {
+                stream.print("new " + Apint.class.getName() + "(l.getLong())");
+            } else if (query_type.isFloatType()) {
+                stream.print("l.getDouble()");
+            } else if (query_type.isRatType()) {
+                stream.print("new " + Aprational.class.getName() + "(l.getDouble())");
+            } else if (query_type.isStringType()) {
+                stream.print("l.getString()");
+            } else {
+                // unreachable: query result is type-checked before code
+                // generation starts
+                throw new JavaBackendException(body, "Unexpected return type for SPARQL query; probably a type-checking bug");
+            }
+            stream.println(");");
+            stream.println("}");
+        } else if (query_type.isInterfaceType()) {
+            InterfaceType int_query_t = (InterfaceType)query_type;
+            // handle singleton interface return value
+            stream.println("String varName = solution.varNames().next();");
+            stream.println("var o = solution.get(varName);");
+            stream.println("if (o.isResource()) {");
+            stream.println("var absObject = " + obs + ".findObjectForResource(o.asResource().getURI());");
+            stream.println("if (absObject instanceof " + JavaBackend.getQualifiedString(int_query_t) + ") {");
+            stream.print("acc.add(0, absObject);");
+            stream.println("}");
+            stream.println("}");
+        } else {
+            // TODO: implement datatype construction
+            throw new JavaBackendException(body, "Unexpected return type for SPARQL query; probably a type-checking bug");
+        }
         stream.println("}");
         stream.println("for (Object row : acc) {");
         stream.println("result = new ABS.StdLib.List_Cons(row, result);");

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/WeakValueHashMap.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/WeakValueHashMap.java
@@ -1,0 +1,110 @@
+package org.abs_models.backend.java.lib;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A hashmap with weak values.
+ */
+public class WeakValueHashMap<K, V> implements Map {
+    // See
+    // https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/WeakHashMap.java
+    // but we implement weak values instead of weak keys, and
+    // implement things by wrapping another hash table since that is
+    // easier to read.
+
+    private static final class ValueEntry<K, V> extends WeakReference<V> {
+        // We store the key in addition to the value so that `expunge`
+        // can remove the map entry when `value` gets
+        // garbage-collected
+        final K key;
+        ValueEntry(K key, V value, ReferenceQueue<V> queue) {
+            super(value, queue);
+            this.key = key;
+        }
+    }
+
+    private final Map<K, ValueEntry<K, V>> map = new HashMap<>();
+    private final ReferenceQueue<V> queue = new ReferenceQueue<>();
+
+    private void expunge() {
+        ValueEntry<K, V> entry;
+        while ((entry = (ValueEntry<K, V>) queue.poll()) != null) {
+            map.remove(entry.key);
+        }
+    }
+
+    public V put(Object key, Object value) {
+        expunge();
+        V result = get(key);
+        map.put((K)key, new ValueEntry<>((K)key, (V)value, queue));
+        return result;
+    }
+
+    public void putAll(Map m) {
+        expunge();
+        m.forEach((k, v) -> map.put((K)k, new ValueEntry<>((K)k, (V)v, queue)));
+    }
+
+    public V get(Object key) {
+        expunge();
+        ValueEntry<K, V> entry = map.get(key);
+        return entry == null ? null : entry.get();
+    }
+
+    public V remove(Object key) {
+        expunge();
+        V result = get(key);
+        map.remove(key);
+        return result;
+    }
+
+    public Set<K> keySet() {
+        expunge();
+        return map.keySet();
+    }
+
+    public Set<Map.Entry<K, V>> entrySet() {
+        expunge();
+        return map.entrySet().stream()
+            .map(Map.Entry::getValue)
+            .filter(e -> e != null)
+            .map(e -> new AbstractMap.SimpleImmutableEntry<K, V>(e.key, e.get()))
+            .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public Collection<V> values() {
+        expunge();
+        return map.entrySet().stream()
+            .map(Map.Entry::getValue)
+            .filter(e -> e != null)
+            .map(e -> e.get())
+            .toList();
+    }
+
+    public int size() {
+        expunge();
+        return map.size();
+    }
+
+    public boolean isEmpty() {
+        expunge();
+        return map.isEmpty();
+    }
+
+    public void clear() {
+        expunge(); // clear the queue just in case; not optimizing this for now
+        map.clear();
+    }
+
+    public boolean containsKey(Object key) {
+        expunge();
+        return map.containsKey(key);
+    }
+
+    public boolean containsValue(Object value) {
+        return values().contains(value);
+    }
+}

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/StartUp.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/StartUp.java
@@ -34,7 +34,10 @@ public class StartUp {
         final boolean useRDF = options.printRDF.isTrue()
                                || options.sparqlQuery.wasSet()
                                // for the SPARQL endpoint
-                               || options.modelapiPort.wasSet();
+                               || options.modelapiPort.wasSet()
+                               // TODO: check if the model contains
+                               // sparql queries
+                               || true;
         ABSRuntime.setRunsInOwnProcess(true);
         Config.initRuntimeFromOptions(runtime, options);
         runtime.addSystemObserver(new DefaultSystemObserver() {

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
@@ -1,33 +1,12 @@
 package org.abs_models.backend.java.observing;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-
+import org.abs_models.backend.java.lib.WeakValueHashMap;
 import org.abs_models.backend.java.lib.runtime.ABSObject;
 import org.abs_models.backend.java.lib.runtime.COG;
 import org.abs_models.backend.java.lib.runtime.Logging;
 import org.abs_models.backend.java.lib.types.ABSAlgebraicDataType;
 import org.abs_models.backend.java.lib.types.ABSInterface;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.query.ResultSetFormatter;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -40,6 +19,15 @@ import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apfloat.Apint;
 import org.apfloat.Aprational;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * An observer that follows cog (and, transitively, object) creation.
@@ -57,7 +45,7 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
         "prog", "http://abs-models.org/ns/prog/",
         "run", "http://abs-models.org/ns/run/");
 
-    static String sparqlPrefix = absNamespaces.entrySet()
+    public static String sparqlPrefix = absNamespaces.entrySet()
         .stream()
         .map(e -> "PREFIX " + e.getKey() + ": <" + e.getValue() + ">\n")
         .collect(Collectors.joining());
@@ -109,9 +97,11 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
                 });
     }
 
-    // Note: iterate over the sets below using a snapshot to avoid gc
-    // messing with us: `for (Object obj : Set.copyOf(objectSet)) { }`
-    private static Set<ObjectView> objectSet = Collections.newSetFromMap(new WeakHashMap<ObjectView, Boolean>());
+    // Note: do not iterate over these two data structures directly
+    // since the garbage collector could remove entries at any time;
+    // instead, use a snapshot, for example `for (Object obj :
+    // Set.copyOf(cogSet)) { /* ... */ }`
+    private static Map<String, ObjectView> objectMap = new WeakValueHashMap<String, ObjectView>();
     private static Set<COGView> cogSet = Collections.newSetFromMap(new WeakHashMap<COGView, Boolean>());
 
     /**
@@ -125,19 +115,25 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
 
     /**
      * Deactivate garbage collection of registered objects and sets,
-     * and make these sets immmutable.  Should be done at the end of
-     * the model run to preserve the ending state.
+     * and make these sets immmutable.  Done at the end of the model
+     * run to preserve the ending state before printing the RDF graph
+     * and/or running a SPARQL query from the command line.
      */
     public static synchronized void freezeObserver() {
-        objectSet = Set.copyOf(objectSet);
+        objectMap = Map.copyOf(objectMap);
         cogSet = Set.copyOf(cogSet);
+    }
+
+    /// Create the URI of a resource representing an ABS object.
+    private static String objectResourceName(Object o) {
+        return absNamespaces.get("run") + "obj" + o.hashCode();
     }
 
     /**
      * Note an object to be added to the object graph.
      */
     public static synchronized void addObject(ObjectView o) {
-        objectSet.add(o);
+        objectMap.put(objectResourceName(o.getObject()), o);
     }
 
     /**
@@ -161,6 +157,16 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
 
     @Override
     public void objectInitialized(ObjectView o) { }
+
+    /**
+     * Find the ABS object named by the given resource in the RDF
+     * model.  Returns `null` if none found.
+     */
+    public static ABSObject findObjectForResource(String r) {
+        ObjectView v = objectMap.get(r);
+        if (v == null) return null;
+        else return v.getObject();
+    }
 
     /**
      * Run a SPARQL query over the current ABS state.  The {@code
@@ -207,12 +213,13 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
      * Return an RDF model of the current ABS state.
      */
     public static Model getModel() {
-        Set<ObjectView> objects = Set.copyOf(objectSet);
+        // Copy the weak map and set to pacify the gc
+        Map<String, ObjectView> objects = Map.copyOf(objectMap);
         Set<COGView> cogs = Set.copyOf(cogSet);
         Model model = ModelFactory.createDefaultModel();
         initNamespaces(model);
         model.add(progModel);
-        for (ObjectView view : objects) {
+        for (ObjectView view : objects.values()) {
             addObjectTriples(model, view);
         }
         for (COGView view : cogs) {
@@ -231,7 +238,7 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
         return model;
     }
 
-    public static void addCogTriples(Model model, COGView view) {
+    private static void addCogTriples(Model model, COGView view) {
         COG cog = view.getCOG();
         ABSInterface dc = cog.getDC();
         String absNS = absNamespaces.get("abs");
@@ -239,7 +246,7 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
         Resource cogRes = model.createResource(runNS + "cog" + cog.hashCode(),
             model.createResource(absNS + "cog"));
         Property inProp = model.createProperty(absNS + "in");
-        cogRes.addProperty(inProp, model.createResource(runNS + "obj" + dc.hashCode()));
+        cogRes.addProperty(inProp, model.createResource(objectResourceName(dc)));
     }
 
     /**
@@ -253,7 +260,7 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
         String progNS = absNamespaces.get("prog");
         String runNS = absNamespaces.get("run");
         Resource classRes = knownClasses.getOrDefault(type, model.createResource(progNS + type));
-        Resource objRes = model.createResource(runNS + "obj" + obj.hashCode(), classRes);
+        Resource objRes = model.createResource(objectResourceName(obj), classRes);
         Property inProp = model.createProperty(absNS + "in");
         objRes.addProperty(inProp, model.createResource(runNS + "cog" + obj.getCOG().hashCode()));
         for (String fieldName : obj.getFieldNames()) {
@@ -296,7 +303,7 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
                     currentRes.addLiteral(currentProp, model.createTypedLiteral(r.doubleValue()));
                     break;
                 case ABSObject o2:
-                    currentRes.addProperty(currentProp, model.createResource(runNS + "obj" + o2.hashCode()));
+                    currentRes.addProperty(currentProp, model.createResource(objectResourceName(o2)));
                     break;
                 case ABSAlgebraicDataType a:
                     // Create the resource for this algebraic data type

--- a/frontend/src/main/java/org/abs_models/frontend/analyser/Builtins.jrag
+++ b/frontend/src/main/java/org/abs_models/frontend/analyser/Builtins.jrag
@@ -4,6 +4,12 @@ aspect Builtins {
     eq BuiltinFunctionDef.isSQLite3Query() = getNumArgument() >= 3
         && getArgument(0) instanceof VarUse
         && ((VarUse)getArgument(0)).getName().equals("sqlite3");
+
+    syn boolean BuiltinFunctionDef.isSparqlQuery();
+    eq BuiltinFunctionDef.isSparqlQuery() = getNumArgument() >= 2
+        && getArgument(0) instanceof VarUse
+        && ((VarUse)getArgument(0)).getName().equals("sparql");
+
 }
 // Local Variables:
 // mode: java

--- a/frontend/src/main/java/org/abs_models/frontend/analyser/ErrorMessage.java
+++ b/frontend/src/main/java/org/abs_models/frontend/analyser/ErrorMessage.java
@@ -165,7 +165,9 @@ public enum ErrorMessage {
 
     SQLITE3_INCORRECT_ARGUMENTS("SQLite3 query functions must have three or more arguments: `sqlite3', a string containing the database filename, a string with the SQL query, and an expression of type String, Boolean or numeric for each query parameter."),
     SQLITE3_INCORRECT_QUERY_ARGUMENT("SQLite3 query arguments must be expressions of type String, Boolean, Int, Float or Rat."),
-    SQLITE3_INCORRECT_RETURN_TYPE("SQLite3 query functions must return a list of values that can be converted from SQL types.")
+    SQLITE3_INCORRECT_RETURN_TYPE("SQLite3 query functions must return a list of values that can be converted from SQL types."),
+    SPARQL_INCORRECT_ARGUMENTS("Sparql query functions must have two arguments: `sparql' and a string containing the SPARQL query."),
+    SPARQL_INCORRECT_RETURN_TYPE("Sparql query functions must return a list of values that can be converted from Sparql.")
     ;
 
     private String pattern;

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/TypeChecker.jadd
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/TypeChecker.jadd
@@ -345,36 +345,46 @@ aspect TypeChecker {
                 TypeCheckerHelper.checkAssignment(e,this,getTypeUse().getType(), def.getRhs());
             }
         } else {
-	    BuiltinFunctionDef def = (BuiltinFunctionDef)getFunctionDef();
-	    // do not use def.isSQLiteQuery() here since we want to
-	    // detect incorrect argument counts etc.
-	    if (def.getNumArgument() > 0
-		&& def.getArgument(0) instanceof VarOrFieldUse
-		&& ((VarUse)def.getArgument(0)).getName().equals("sqlite3"))
-	    {
-		// check function result type: must be a list of basic type or type with constructor.
-		if (!TypeCheckerHelper.isValidSQLite3ReturnType(getTypeUse().getType())) {
-		    e.add(new TypeError(getTypeUse(), ErrorMessage.SQLITE3_INCORRECT_RETURN_TYPE, ""));
-		}
-		// check `builtin' parameters
-		if (def.getNumArgument() < 3) {
-		    e.add(new TypeError(def, ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
-		} else if (!(def.getArgument(1) instanceof StringLiteral)) {
-		    e.add(new TypeError(def.getArgument(1), ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
-		} else if ((!(def.getArgument(2) instanceof StringLiteral))) {
-		    e.add(new TypeError(def.getArgument(2), ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
-		}
-                for (int i = 3; i < def.getNumArgument(); i++) {
-                    if (!(def.getArgument(i) instanceof PureExp)) {
-                        e.add(new TypeError(def.getArgument(i), ErrorMessage.SQLITE3_INCORRECT_QUERY_ARGUMENT, ""));
-                        continue;
+            BuiltinFunctionDef def = (BuiltinFunctionDef)getFunctionDef();
+            if (def.getNumArgument() > 0 && def.getArgument(0) instanceof VarOrFieldUse) {
+                // Check correctness of various "special" queries.  We
+                // do not use def.isSQLiteQuery() or similar here
+                // since we want to detect and report incorrect
+                // argument counts etc.
+                VarOrFieldUse queryType = (VarOrFieldUse)def.getArgument(0);
+                if (queryType.getName().equals("sqlite3")) {
+                    if (!TypeCheckerHelper.isValidSQLite3ReturnType(getTypeUse().getType())) {
+                        e.add(new TypeError(getTypeUse(), ErrorMessage.SQLITE3_INCORRECT_RETURN_TYPE, ""));
                     }
-                    PureExp arg = (PureExp)def.getArgument(i);
-                    if (!TypeCheckerHelper.isValidSQLite3ArgumentType(arg.getType())) {
-                        e.add(new TypeError(def.getArgument(i), ErrorMessage.SQLITE3_INCORRECT_QUERY_ARGUMENT, ""));
+                    // check `builtin' parameters
+                    if (def.getNumArgument() < 3) {
+                        e.add(new TypeError(def, ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
+                    } else if (!(def.getArgument(1) instanceof StringLiteral)) {
+                        e.add(new TypeError(def.getArgument(1), ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
+                    } else if ((!(def.getArgument(2) instanceof StringLiteral))) {
+                        e.add(new TypeError(def.getArgument(2), ErrorMessage.SQLITE3_INCORRECT_ARGUMENTS, ""));
+                    }
+                    for (int i = 3; i < def.getNumArgument(); i++) {
+                        if (!(def.getArgument(i) instanceof PureExp)) {
+                            e.add(new TypeError(def.getArgument(i), ErrorMessage.SQLITE3_INCORRECT_QUERY_ARGUMENT, ""));
+                            continue;
+                        }
+                        PureExp arg = (PureExp)def.getArgument(i);
+                        if (!TypeCheckerHelper.isValidSQLite3ArgumentType(arg.getType())) {
+                            e.add(new TypeError(def.getArgument(i), ErrorMessage.SQLITE3_INCORRECT_QUERY_ARGUMENT, ""));
+                        }
+                    }
+                } else if (queryType.getName().equals("sparql")) {
+                    if (!TypeCheckerHelper.isValidSparqlReturnType(getTypeUse().getType())) {
+                        e.add(new TypeError(getTypeUse(), ErrorMessage.SPARQL_INCORRECT_RETURN_TYPE, ""));
+                    }
+                    if (def.getNumArgument() != 2) {
+                        e.add(new TypeError(def, ErrorMessage.SPARQL_INCORRECT_ARGUMENTS, ""));
+                    } else if (!(def.getArgument(1) instanceof StringLiteral)) {
+                        e.add(new TypeError(def.getArgument(1), ErrorMessage.SPARQL_INCORRECT_ARGUMENTS, ""));
                     }
                 }
-	    }
+            }
         }
     }
 
@@ -1385,19 +1395,19 @@ aspect TypeCheckProductline {
         }
     }
 
-	public abstract boolean Value.isAssignableTo(Type t);
-	public boolean BoolVal.isAssignableTo(Type t) {
-		return t.isBoolType();
-	}
-	public boolean StringVal.isAssignableTo(Type t) {
+        public abstract boolean Value.isAssignableTo(Type t);
+        public boolean BoolVal.isAssignableTo(Type t) {
+                return t.isBoolType();
+        }
+        public boolean StringVal.isAssignableTo(Type t) {
             return t.isStringType();
-	}
-	public boolean IntVal.isAssignableTo(Type t) {
-		return t.isNumericType();
-	}
+        }
+        public boolean IntVal.isAssignableTo(Type t) {
+                return t.isNumericType();
+        }
         public boolean UnknownVal.isAssignableTo(Type t) {
             return false;
-	}
+        }
 
 
     protected void DeltaClause.typeCheck(Map<String,DeltaDecl> ds, Set<String> definedFeatures, SemanticConditionList e) {
@@ -1425,18 +1435,18 @@ aspect TypeCheckProductline {
     eq DeltaClassParam.getType() = UnknownType.INSTANCE; // XXX
     eq DeltaFieldParam.getType() = getParamDecl().getType();
 
-	public abstract boolean DeltaParamDecl.accepts(Value val);
-	public boolean DeltaClassParam.accepts(Value val) { return true; /* XXX NYI? */ }
-	public boolean DeltaFieldParam.accepts(Value val) {
+        public abstract boolean DeltaParamDecl.accepts(Value val);
+        public boolean DeltaClassParam.accepts(Value val) { return true; /* XXX NYI? */ }
+        public boolean DeltaFieldParam.accepts(Value val) {
       return val.isAssignableTo(getType());
-	}
+        }
 
-	syn boolean DeltaClause.refersTo(Feature f) = !hasAppCond() || getAppCond().refersTo(f);
-	syn boolean AppCond.refersTo(Feature f);
-	eq AppCondFeature.refersTo(Feature f) = getName().equals(f.getName());
-	eq AppCondAnd.refersTo(Feature f) = getLeft().refersTo(f) || getRight().refersTo(f);
-	eq AppCondOr.refersTo(Feature f) = getLeft().refersTo(f) || getRight().refersTo(f);
-	eq AppCondNot.refersTo(Feature f) = getAppCond().refersTo(f);
+        syn boolean DeltaClause.refersTo(Feature f) = !hasAppCond() || getAppCond().refersTo(f);
+        syn boolean AppCond.refersTo(Feature f);
+        eq AppCondFeature.refersTo(Feature f) = getName().equals(f.getName());
+        eq AppCondAnd.refersTo(Feature f) = getLeft().refersTo(f) || getRight().refersTo(f);
+        eq AppCondOr.refersTo(Feature f) = getLeft().refersTo(f) || getRight().refersTo(f);
+        eq AppCondNot.refersTo(Feature f) = getAppCond().refersTo(f);
 }
 
 // Local Variables:

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/TypeCheckerHelper.java
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/TypeCheckerHelper.java
@@ -138,18 +138,13 @@ public class TypeCheckerHelper {
     }
 
     public static void checkForGetOnDestiny(SemanticConditionList l, ASTNode<?> node, String targetFieldOrVariableName, Exp potentialGetValue) {
-        if (potentialGetValue instanceof GetExp) {
-            final GetExp getValue = (GetExp) potentialGetValue;
-
+        if (potentialGetValue instanceof GetExp getValue) {
             if (getValue.getType().isBottomType()) {
                 l.add(new TypeError(
-                            node,
-                            ErrorMessage.CANNOT_STORE_DESTINY_GET,
-                            new String[] {
-                                getValue.getPureExp().toString(),
-                                targetFieldOrVariableName
-                            }
-                        )
+                    node,
+                    ErrorMessage.CANNOT_STORE_DESTINY_GET,
+                    getValue.getPureExp().toString(),
+                    targetFieldOrVariableName)
                 );
             }
         }
@@ -414,9 +409,9 @@ public class TypeCheckerHelper {
             String location = "";
             Decl decl = null;
             if (origrn instanceof ResolvedDeclName) {
-                decl = ((ResolvedDeclName)origrn).getDecl();
+                decl = origrn.getDecl();
             } else if (origrn instanceof ResolvedAmbigiousName) {
-                decl = ((AmbiguousDecl)((ResolvedAmbigiousName)origrn).getDecl()).getAlternative().get(0);
+                decl = ((AmbiguousDecl) origrn.getDecl()).getAlternative().get(0);
             }
             if (decl != null && !decl.getFileName().equals(Main.UNKNOWN_FILENAME)) {
                 location = " at " + decl.getFileName() + ":" + decl.getStartLine() + ":" + decl.getStartColumn();
@@ -463,8 +458,7 @@ public class TypeCheckerHelper {
             res.put(rn.getSimpleName(), rn);
             res.put(rn.getQualifiedName(), rn);
 
-            if (d instanceof DataTypeDecl) {
-                DataTypeDecl dataDecl = (DataTypeDecl) d;
+            if (d instanceof DataTypeDecl dataDecl) {
                 for (DataConstructor c : dataDecl.getDataConstructors()) {
                     rn = new ResolvedDeclName(moduleName, c);
                     if (res.containsKey(rn.getSimpleName()))
@@ -497,14 +491,12 @@ public class TypeCheckerHelper {
         ResolvedMap res = new ResolvedMap();
 
         for (Import i : mod.getImports()) {
-            if (i instanceof StarImport) {
-                StarImport si = (StarImport) i;
+            if (i instanceof StarImport si) {
                 ModuleDecl md = mod.lookupModule(si.getModuleName());
                 if (md != null) {
                     res.addAllNamesNoHiding(md.getExportedNames());
                 }
-            } else if (i instanceof NamedImport) {
-                NamedImport ni = (NamedImport) i;
+            } else if (i instanceof NamedImport ni) {
                 for (Name n : ni.getNames()) {
                     // statements like "import X;" lead to earlier type error;
                     // avoid calling lookupModule(null) here
@@ -516,8 +508,7 @@ public class TypeCheckerHelper {
                             } catch (TypeCheckerException e) {} // NADA
                     }
                 }
-            } else if (i instanceof FromImport) {
-                FromImport fi = (FromImport) i;
+            } else if (i instanceof FromImport fi) {
                 ModuleDecl md = mod.lookupModule(fi.getModuleName());
                 if (md != null) {
                     ResolvedMap en = md.getExportedNames();
@@ -553,23 +544,20 @@ public class TypeCheckerHelper {
     public static ResolvedMap getExportedNames(ModuleDecl mod) {
         ResolvedMap res = new ResolvedMap();
         for (Export e : mod.getExports()) {
-            if (e instanceof StarExport) {
-                StarExport se = (StarExport) e;
+            if (e instanceof StarExport se) {
                 if (!se.hasModuleName()) {
                     res.putAll(mod.getDefinedNames());
                 } else {
                     String moduleName = se.getModuleName().getName();
                     res.putNamesOfModule(mod, mod.getVisibleNames(), moduleName, null);
                 }
-            } else if (e instanceof FromExport) {
-                FromExport fe = (FromExport) e;
+            } else if (e instanceof FromExport fe) {
                 String moduleName = fe.getModuleName();
                 for (Name n : fe.getNames()) {
                     String simpleName = n.getSimpleName();
                     res.putNamesOfModule(mod, mod.getVisibleNames(), moduleName, simpleName);
                 }
-            } else if (e instanceof NamedExport) {
-                NamedExport ne = (NamedExport) e;
+            } else if (e instanceof NamedExport ne) {
                 for (Name n : ne.getNames()) {
                     String simpleName = n.getSimpleName();
                     res.putKindedNames(simpleName, mod.getVisibleNames());
@@ -746,24 +734,24 @@ public class TypeCheckerHelper {
     /**
      * Check whether argument t can be an argument to a SQLite3 query.
      *
-     * This method returns true if t is a string, numeric or boolean type.
+     * <p>This method returns true if t is a string, numeric or boolean type.
      */
     public static boolean isValidSQLite3ArgumentType(Type t) {
-	if (t.isUnknownType())
-	    return false;
-	else if (!t.isDataType())
-	    return false;
-	DataTypeType lt = (DataTypeType) t;
-	if (lt.isBoolType())
-	    return true;
-	else if (lt.isIntType())
-	    return true;
-	else if (lt.isRatType())
-	    return true;
-	else if (lt.isFloatType())
-	    return true;
-	else if (lt.isStringType())
-	    return true;
+        if (t.isUnknownType())
+            return false;
+        else if (!t.isDataType())
+            return false;
+        DataTypeType lt = (DataTypeType) t;
+        if (lt.isBoolType())
+            return true;
+        else if (lt.isIntType())
+            return true;
+        else if (lt.isRatType())
+            return true;
+        else if (lt.isFloatType())
+            return true;
+        else if (lt.isStringType())
+            return true;
         else
             return false;
     }
@@ -771,49 +759,92 @@ public class TypeCheckerHelper {
     /**
      * Check whether argument t can be the result of a SQLite3 query.
      *
-     * This method returns true if t is a list whose type parameter is
+     * <p>This method returns true if t is a list whose type parameter is
      * a string, numeric or boolean type, or an algebraic datatype
      * whose first constructor takes parameters of these types.
      */
     public static boolean isValidSQLite3ReturnType(Type t) {
-	    if (t.isUnknownType())
-	        return false;
-	    if (!t.isDataType())
-	        return false;
+            if (t.isUnknownType())
+                return false;
+            if (!t.isDataType())
+                return false;
 
-	    DataTypeType dt = (DataTypeType) t;
-	    if (!(dt.getDecl().getName().equals("List")))
-	        return false;
-	    if (!(dt.numTypeArgs() == 1
-	          && dt.getTypeArg(0).isDataType()))
-	        return false;
+            DataTypeType dt = (DataTypeType) t;
+            if (!(dt.getDecl().getName().equals("List")))
+                return false;
+            if (!(dt.numTypeArgs() == 1
+                  && dt.getTypeArg(0).isDataType()))
+                return false;
 
-	    DataTypeType lt = (DataTypeType)dt.getTypeArg(0);
-	    if (lt.isBoolType())
-	        return true;
-	    if (lt.isIntType())
-	        return true;
-	    if (lt.isRatType())
-	        return true;
-	    if (lt.isFloatType())
-	        return true;
-	    if (lt.isStringType())
-	        return true;
-	    DataTypeDecl ltd = lt.getDecl();
-	    if (ltd.getNumDataConstructor() != 1)
-	        return false;
-	    if (ltd.getDataConstructor(0).getNumConstructorArg() < 1)
-	        return false;
-	    for (ConstructorArg ca : ltd.getDataConstructor(0).getConstructorArgList()) {
-	        Type cat = ca.getTypeUse().getType();
-	        if (!(cat.isBoolType()
-		          || cat.isIntType()
-		          || cat.isRatType()
-		          || cat.isFloatType()
-		          || cat.isStringType()))
-		        return false;
-	    }
-	    return true;
+            DataTypeType lt = (DataTypeType)dt.getTypeArg(0);
+            if (lt.isBoolType())
+                return true;
+            if (lt.isIntType())
+                return true;
+            if (lt.isRatType())
+                return true;
+            if (lt.isFloatType())
+                return true;
+            if (lt.isStringType())
+                return true;
+            DataTypeDecl ltd = lt.getDecl();
+            if (ltd.getNumDataConstructor() != 1)
+                return false;
+            if (ltd.getDataConstructor(0).getNumConstructorArg() < 1)
+                return false;
+            for (ConstructorArg ca : ltd.getDataConstructor(0).getConstructorArgList()) {
+                Type cat = ca.getTypeUse().getType();
+                if (!(cat.isBoolType()
+                          || cat.isIntType()
+                          || cat.isRatType()
+                          || cat.isFloatType()
+                          || cat.isStringType()))
+                        return false;
+            }
+            return true;
+    }
+
+    /**
+     * Check whether argument t can be the result of a SPARQL query.
+     *
+     * <p>This method returns true if t is a list whose type parameter is
+     * a string, numeric or boolean type, an interface type, or an
+     * algebraic datatype whose first constructor takes parameters of
+     * these types.
+     */
+    public static boolean isValidSparqlReturnType(Type t) {
+        if (t.isUnknownType())
+            return false;
+        if (!t.isDataType())
+            return false;
+
+        DataTypeType dt = (DataTypeType) t;
+        if (!(dt.getDecl().getName().equals("List")))
+            return false;
+        if (!(dt.numTypeArgs() == 1))
+            return false;
+
+        Type at = dt.getTypeArg(0);
+
+        if (at.isBoolType() || at.isNumericType() || at.isStringType() || at.isInterfaceType())
+            return true;
+
+        if (!at.isDataType()) return false;
+        DataTypeType lt = (DataTypeType)at;
+        DataTypeDecl ltd = lt.getDecl();
+        if (ltd.getNumDataConstructor() != 1)
+            return false;
+        if (ltd.getDataConstructor(0).getNumConstructorArg() < 1)
+            return false;
+        for (ConstructorArg ca : ltd.getDataConstructor(0).getConstructorArgList()) {
+            Type cat = ca.getTypeUse().getType();
+            if (!(cat.isBoolType()
+                  || cat.isNumericType()
+                  || cat.isStringType()
+                  || cat.isInterfaceType()))
+                return false;
+        }
+        return true;
     }
 
     /**
@@ -842,7 +873,7 @@ public class TypeCheckerHelper {
         if (t.getDecl() instanceof DataTypeDecl d) {
             Set<String> constructors = ListUtils.toJavaList(d.getDataConstructors())
                 .stream()
-                .map(c -> c.getName())
+                .map(DataConstructor::getName)
                 .collect(Collectors.toSet());
             Set<String> usedConstructors = new HashSet<>();
             // have to iterate over constructors

--- a/frontend/src/test/java/org/abs_models/backend/BackendTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/BackendTestDriver.java
@@ -29,6 +29,8 @@ public interface BackendTestDriver {
 
     public abstract boolean supportsSQLite();
 
+    public abstract boolean supportsSPARQL();
+
     public abstract void assertEvalEquals(String absCode, boolean value) throws Exception;
 
     public abstract void assertEvalFails(String absCode) throws Exception;

--- a/frontend/src/test/java/org/abs_models/backend/common/DataSourceTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/common/DataSourceTests.java
@@ -1,4 +1,4 @@
-/** 
+/**
  * Copyright (c) 2021, Rudolf Schlatte.
  * This file is licensed under the terms of the Modified BSD License.
  */
@@ -50,4 +50,11 @@ public class DataSourceTests extends SemanticTests {
         assertEvalTrueWithTestfiles(new File("abssamples/backend/DatasourceTests/sqlite3_functioncall_parameters.abs"),
             new File("sqlite3/test.sqlite3"));
     }
+
+    @Test
+    public void querySparql() throws Exception {
+        Assume.assumeTrue("Only meaningful with SPARQL support", driver.supportsSPARQL());
+        assertEvalTrue(new File("abssamples/backend/DatasourceTests/sparql.abs"));
+    }
+
 }

--- a/frontend/src/test/java/org/abs_models/backend/common/SemanticTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/common/SemanticTests.java
@@ -16,8 +16,6 @@ import org.abs_models.ABSTest;
 import org.abs_models.backend.BackendTestDriver;
 import org.abs_models.backend.erlang.ErlangTestDriver;
 import org.abs_models.backend.java.JavaTestDriver;
-import org.abs_models.backend.maude.MaudeCompiler;
-import org.abs_models.backend.maude.MaudeTestDriver;
 import org.abs_models.frontend.ast.Model;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/erlang/ErlangTestDriver.java
@@ -468,6 +468,9 @@ public class ErlangTestDriver extends ABSTest implements BackendTestDriver {
     public boolean supportsSQLite() { return true; }
 
     @Override
+    public boolean supportsSPARQL() { return false; }
+
+    @Override
     public boolean supportsModelApi() {
         return true;
     }

--- a/frontend/src/test/java/org/abs_models/backend/java/JavaTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/java/JavaTestDriver.java
@@ -88,6 +88,9 @@ public class JavaTestDriver extends ABSTest implements BackendTestDriver {
     public boolean supportsSQLite() { return true; }
 
     @Override
+    public boolean supportsSPARQL() { return true; }
+
+    @Override
     public boolean supportsModelApi() {
         return true;
     }

--- a/frontend/src/test/java/org/abs_models/backend/java/dynamic/JavaDynamicTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/java/dynamic/JavaDynamicTestDriver.java
@@ -71,6 +71,9 @@ public class JavaDynamicTestDriver implements BackendTestDriver {
     public boolean supportsSQLite() { return false; }
 
     @Override
+    public boolean supportsSPARQL() { return false; }
+
+    @Override
     public boolean supportsModelApi() {
         return false;
     }

--- a/frontend/src/test/java/org/abs_models/backend/maude/MaudeTestDriver.java
+++ b/frontend/src/test/java/org/abs_models/backend/maude/MaudeTestDriver.java
@@ -75,6 +75,9 @@ public class MaudeTestDriver implements BackendTestDriver {
     public boolean supportsSQLite() { return false; }
 
     @Override
+    public boolean supportsSPARQL() { return false; }
+
+    @Override
     public boolean supportsModelApi() {
         return false;
     }

--- a/frontend/src/test/resources/abssamples/backend/DatasourceTests/sparql.abs
+++ b/frontend/src/test/resources/abssamples/backend/DatasourceTests/sparql.abs
@@ -1,0 +1,43 @@
+module BackendTest;
+
+interface I {}
+
+class C(String s, Int i) implements I {
+}
+
+def List<String> query_strings() = builtin(sparql,
+    `SELECT ?s WHERE {
+       ?o a/rdfs:label "BackendTest.C" ;
+          prog:BackendTest.s ?s .
+     }
+     ORDER BY ?s`);
+
+def List<Int> query_ints() = builtin(sparql,
+    `SELECT ?i WHERE {
+       ?o a/rdfs:label "BackendTest.C" ;
+          prog:BackendTest.i ?i .
+     }
+     ORDER BY ?i`);
+
+def List<I> query_objs() = builtin(sparql,
+    `SELECT ?o WHERE {
+       ?o a/rdfs:label "BackendTest.C" .
+     }`);
+
+  def List<I> query_interfaces() = builtin(sparql,
+      `SELECT ?o WHERE {
+         ?o a/abs:implements/rdfs:label "BackendTest.I" .
+       }`);
+
+{
+    I o = new local C("hello", 15);
+    I o2 = new C("world", 1);
+
+    Bool testresult = query_strings() == list["hello", "world"]
+        && query_ints() == list[1, 15];
+
+    List<I> objs = query_objs();
+    testresult = testresult && set[o, o2] == set(objs);
+    List<I> interfaces = query_interfaces();
+    testresult = testresult && set[o, o2] == set(interfaces);
+}

--- a/website/README.md
+++ b/website/README.md
@@ -17,6 +17,8 @@ docker collaboratory container and at https://abs-models.org.
 - [X] Convert Publications
 - [X] Convert Contact
 - [X] Convert Acknowledgments
+- [X] Implement glossary
+- [ ] Implement index
 - [ ] Implement bibliography
 
 

--- a/website/src/site/sphinx/manual/backends.rst
+++ b/website/src/site/sphinx/manual/backends.rst
@@ -244,20 +244,26 @@ The Java backend supports *semantic lifting*, i.e., obtaining a
 semantic representation of aspects of the model and the runtime state.
 The data is provided in RDF form.
 
+An ABS model can query its own state at runtime -- see
+:ref:`sparql-queries`.  The rest of this section describes how to work
+with semantically-lifted models from outside, i.e., from the command
+line or the Model API.
+
 When an ABS model is started with the ``--printRDF`` argument, this
 semantic representation is printed to the terminal in `TRTL format
 <https://www.w3.org/TR/turtle/>`__ after the model finishes.
 
 When an ABS model is started with the ``--sparqlQuery`` argument
 followed by a valid SPARQL query, that query is run after the model
-finishes, and its result printed in TRTL form.
+finishes, and its result is printed in TRTL form.
 
-When an ABS model is run with the Model API active, it provides a
-SPARQL endpoint under the ``/sparql`` URL.  The endpoint accepts
-SPARQL queries following the `SPARQL 1.1 Protocol
-<https://www.w3.org/TR/sparql11-protocol/>`__ and by default returns
-results in `JSON format
-<https://www.w3.org/TR/sparql11-results-json/>`__.
+When an ABS model is running with the :ref:`Model API <sec:model-api>`
+active, it provides a SPARQL endpoint under the ``/sparql`` URL.  The
+endpoint accepts SPARQL queries as specified in `Section 2.1
+<https://www.w3.org/TR/sparql11-protocol/#query-operation>`__ of the
+`SPARQL 1.1 Protocol <https://www.w3.org/TR/sparql11-protocol/>`__.
+The sparql endpoint returns results in `JSON format
+<https://www.w3.org/TR/sparql11-results-json/>`__ by default.
 
 
 .. _sec:erlang-backend:

--- a/website/src/site/sphinx/manual/classes.rst
+++ b/website/src/site/sphinx/manual/classes.rst
@@ -16,14 +16,14 @@ library interface ``ABS.StdLib.Object`` (see :ref:`type-object`).  The
 ``ABS.StdLib.Object`` interface does not specify any methods.
 
 .. note:: Classes typically explicitly implement one or more
-          interfaces so that methods can be called on them, but the
+          interfaces so that they can receive method calls, but the
           ``run`` method makes it meaningful to have objects without
           public methods; such objects cannot accept method calls but
           can send method calls to other objects.
 
-NOTE: For ease of reasoning and analysis, ABS methods differ only by
-name.  It is an error for a class to implement two interfaces that
-both contain a method with the same name.
+.. note:: For ease of reasoning and analysis, ABS methods differ only
+          by name.  It is an error for a class to implement two
+          interfaces that both contain a method with the same name.
 
 Classes have *fields* that define the state of objects of that class.
 All fields are private and can only be accessed from methods defined
@@ -79,9 +79,9 @@ one of the used traits (see :ref:`sec:traits`).  A class is free to
 define methods not declared in an interface; such methods are private
 to the class and cannot be called from outside the class.
 
-NOTE: ABS currently does not support method overloading.  Each method
-must have a unique name since methods are not disambiguated by their
-parameter lists.
+.. note:: ABS currently does not support method overloading.  Each
+          method must have a unique name since methods are not
+          disambiguated by their parameter lists.
 
 Example::
 

--- a/website/src/site/sphinx/manual/functions.rst
+++ b/website/src/site/sphinx/manual/functions.rst
@@ -328,3 +328,105 @@ directory is the value of the erlang function
 backend, the path to the database file is resolved relative to the
 current path of the process running the model.
 
+
+.. _sparql-queries:
+
+SPARQL Queries over Semantic State
+==================================
+
+The Java backend supports *semantic lifting*, i.e., obtaining a
+semantic representation of aspects of the model and the runtime state.
+The data is provided in RDF form.
+
+ABS models using the Java backends can use the :term:`SPARQL` query
+language to query the runtime state as an RDF triple graph.  A SPARQL
+query is defined by writing a function with a ``builtin`` body with
+two arguments: a literal ``sparql`` followed by the query as a SPARQL
+string.
+
+The result of a SPARQL query is converted into an ABS list of values.
+
+Currently only the first SPARQL variable listed in the ``SELECT``
+clause is used to construct the ABS return value.  Valid return types
+of ``builtin`` SPARQL query functions are:
+
+- ``List<Int>`` when the first SPARQL variable is a RDF literal that
+  can be converted to an integer;
+
+- ``List<Float>`` when the first SPARQL variable is a RDF literal that
+  can be converted to a float;
+
+- ``List<Rat>`` ditto;
+
+- ``List<Bool>`` when the first SPARQL variable is a RDF literal that
+  can be converted to a Boolean;
+
+- ``List<String>`` when the first SPARQL variable is a RDF literal;
+
+- ``List<I>`` when ``I`` names an interface, and the first SPARQL
+  variable is a RDF resource that names an ABS object whose class
+  implements that interface.
+
+.. note:: It is an error if the resources found by a query where ABS
+          expects objects of type ``I`` do not represent ABS objects
+          that implement ``I``, but currently such objects are
+          silently dropped when creating the result.
+
+The following namespaces are always defined:
+
+``abs:``
+   the ABS language ontology
+
+``prog:``
+   the program ontology; this ontology contains the names of all
+   classes, interfaces, members, datatypes and datatype constructors
+
+``run:``
+   the runtime ontology, containing object references
+
+::
+
+  module Test;
+
+  interface I {}
+
+  class C(Int i) implements I {}
+
+  def List<String> all_integer_field_values() = builtin(sparql, ①
+      `SELECT ?i
+       WHERE { ?obj a/rdfs:label "Test.C" . ②
+               ?obj prog:Test.i ?i . }`); ③
+
+  def List<I> all_I_instances() = builtin(sparql,
+      `SELECT ?o WHERE {
+         ?o a/abs:implements/rdfs:label "BackendTest.I" . ④
+       }`);
+
+
+  {
+      I o1 = new C(5);
+      I o2 = new C(4);
+      I o3 = new C(2);
+      List<String> result = all_integer_field_values(); ⑤
+      List<I> all_I = all_I_instances(); ⑥
+  }
+
+| ① A ``builtin`` function with first argument ``sparql`` takes an
+  additional argument, a SPARQL query string.
+| ② The lifted representation of an ABS class has the ABS qualified
+  name as an ``rdfs:label`` property, so we use a property path
+  `a/rdfs:label` to find class instances.
+| ③ The ``prog:`` namespace contains, among others, all class and
+  attribute definitions.  The ``prog`` ontology uses fully qualified
+  ABS names.
+| ④ This query uses SPARQL *property paths*
+  `<https://www.w3.org/TR/sparql11-property-paths/>`__ to succinctly
+  find resources of a class that implements an interface with a label
+  ``"BackendTest.I"``.
+| ⑤ This query returns a list containing "2", "4", "5" in some
+  permutation.  Since the function returns ``List<String>``, the RDF
+  literals are converted to ABS strings.
+| ⑥ This query returns the list of all objects implementing the
+  interface ``I``.  Note that ABS objects are subject to garbage
+  collection, so otherwise unreferenced objects may or may not be
+  found by the query.

--- a/website/src/site/sphinx/manual/glossary.rst
+++ b/website/src/site/sphinx/manual/glossary.rst
@@ -18,4 +18,14 @@ Glossary
       callee object.  Tasks are scheduled by the cog containing the
       callee object.  Each task has an associated future.
 
+   RDF
+      RDF is a standard model for data interchange on the Web,
+      extending the linking structure of the Web to use URIs to name
+      the relationship between things as well as the two ends of the
+      link; see `<https://www.w3.org/RDF/>`__.
 
+   SPARQL
+      SPARQL is a set of specifications that provide languages and
+      protocols to query and manipulate RDF graph content on the Web
+      or in an RDF store; see
+      `<https://www.w3.org/TR/sparql11-overview/>`__.

--- a/website/src/site/sphinx/manual/modules.rst
+++ b/website/src/site/sphinx/manual/modules.rst
@@ -9,10 +9,10 @@ type aliases) are contained in modules.  All definitions are visible
 in their own module only, except when the module exports the name and
 it is imported in another module or referenced by its qualified name.
 
-NOTE: The ``export`` clause in a module definition exports *names*,
-not definitions as such.  This means that if a module defines a class
-and an interface with the same name, both definitions will be
-accessible if that name is contained in the ``export`` clause.
+.. note:: The ``export`` clause in a module definition exports
+          *names*, not definitions as such.  This means that, for
+          example, a module that defines a class and an interface with
+          the same name cannot export only the interface.
 
 
 Defining a Module

--- a/website/src/site/sphinx/manual/stdlib/exceptions.rst
+++ b/website/src/site/sphinx/manual/stdlib/exceptions.rst
@@ -7,9 +7,9 @@ ABS provides pre-defined exceptions that are thrown in specific
 circumstances.  See :ref:`sec:exception-types` for information about
 exceptions.
 
-NOTE: This list is subject to revision in future versions of ABS.  Not
-all these exceptions are currently thrown by different backends in the
-described situation.
+.. note:: This list is subject to revision in future versions of ABS.
+          Not all these exceptions are currently thrown by different
+          backends in the described situation.
 
 ``DivisionByZeroException``
     Raised in arithmetic expressions when the divisor (denominator) is


### PR DESCRIPTION
Implement a function body with a SPARQL query, analogous to the existing sqlite3 queries.

```
List<String> all_classes() =
  builtin(sparql, "SELECT ?c WHERE { ?c a abs:class }");
```

- [X] Extend BuiltinFunction
- [X] Simple one-variable String queries
- [X] Non-String simple (one-variable) queries
- [X] Queries for objects
- [ ] Non-String multi-variable queries, using datatypes as return value
- [X] Tests
- [x] Documentation