### PR TITLE
Add linking of ABS classes to domain concepts

### DIFF
--- a/frontend/src/main/java/org/abs_models/backend/java/codegeneration/ClassDeclGenerator.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/codegeneration/ClassDeclGenerator.java
@@ -21,6 +21,7 @@ import org.abs_models.backend.java.lib.runtime.COG;
 import org.abs_models.backend.java.lib.runtime.Task;
 import org.abs_models.backend.java.lib.types.ABSClass;
 import org.abs_models.backend.java.scheduling.UserSchedulingStrategy;
+import org.abs_models.frontend.analyser.AnnotationHelper;
 import org.abs_models.frontend.analyser.SemanticConditionList;
 import org.abs_models.frontend.ast.ClassDecl;
 import org.abs_models.frontend.ast.FieldDecl;
@@ -28,6 +29,7 @@ import org.abs_models.frontend.ast.InterfaceTypeUse;
 import org.abs_models.frontend.ast.MethodImpl;
 import org.abs_models.frontend.ast.MethodSig;
 import org.abs_models.frontend.ast.ParamDecl;
+import org.abs_models.frontend.ast.PureExp;
 import org.abs_models.frontend.typechecker.InterfaceType;
 
 public class ClassDeclGenerator {
@@ -68,6 +70,8 @@ public class ClassDeclGenerator {
         generateHttpCallableMethodInfoMethod();
         stream.println();
         generateHttpCallableMethods();
+        stream.println();
+        generateDomainClassMethod();
         stream.println();
         generateFields();
         if (decl.hasParam() || decl.hasField()) {
@@ -125,6 +129,21 @@ public class ClassDeclGenerator {
         }
         stream.println("} catch (NoSuchMethodException | IllegalAccessException e) {");
         stream.println("            throw new ExceptionInInitializerError(e);");
+        stream.println("}");
+        stream.println("}");
+    }
+
+    private void generateDomainClassMethod() {
+        PureExp domainClassAnnotation = AnnotationHelper.getAnnotationValueFromName(decl.getAnnotations(), "ABS.StdLib.DomainClass");
+        if (domainClassAnnotation == null) return;
+        stream.println("public java.util.Optional<String> $domainClass() {");
+        stream.println("try {");
+        stream.println("String result = ");
+        domainClassAnnotation.generateJava(stream);
+        stream.println(";");
+        stream.println("return java.util.Optional.of(result);");
+        stream.println("} catch (Exception e) {");
+        stream.println("return java.util.Optional.empty();");
         stream.println("}");
         stream.println("}");
     }

--- a/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/lib/runtime/ABSObject.java
@@ -6,6 +6,7 @@ package org.abs_models.backend.java.lib.runtime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.abs_models.backend.java.lib.types.ABSRef;
 import org.abs_models.backend.java.lib.types.ABSUnit;
@@ -152,6 +153,12 @@ public abstract class ABSObject implements ABSRef {
 
     // Return value is serializable by the Jackson JSON library
     public abstract List<Map<String, Object>> getHttpCallableMethodInfo();
+
+    /// The resource URI of a domain class linked to a specific ABS
+    /// object instance.
+    public java.util.Optional<String> $domainClass() {
+        return Optional.empty();
+    }
 
     public ABSFut<? extends Object> invokeMethod(String name, List<Object> arguments) {
         return null;

--- a/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
+++ b/frontend/src/main/java/org/abs_models/backend/java/observing/GraphObserver.java
@@ -48,6 +48,8 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
     static Map<String, Resource> knownInterfaces = new HashMap<>();
     static Map<String, Resource> knownDatatypes = new HashMap<>();
     static Map<String, Resource> knownConstructors = new HashMap<>();
+    /// Domain classes referenced by `DomainClass` annotation
+    static Map<String, Resource> knownDomainClasses = new HashMap<>();
 
     /// The domain ontology, specified via command line
     static Model domainModel = ModelFactory.createDefaultModel();
@@ -267,9 +269,14 @@ public class GraphObserver extends DefaultSystemObserver implements ObjectCreati
         String absNS = absNamespaces.get("abs");
         String progNS = absNamespaces.get("prog");
         String runNS = absNamespaces.get("run");
+        Optional<String> domainClass = obj.$domainClass();
         Resource classRes = knownClasses.getOrDefault(type, model.createResource(progNS + type));
         Resource objRes = model.createResource(objectResourceName(obj), classRes);
         Property inProp = model.createProperty(absNS + "in");
+        if (domainClass.isPresent()) {
+            Resource domainClassRes = knownDomainClasses.getOrDefault(domainClass.get(), model.createResource(domainClass.get()));
+            objRes.addProperty(RDF.type, domainClassRes);
+        }
         objRes.addProperty(inProp, model.createResource(runNS + "cog" + obj.getCOG().hashCode()));
         for (String fieldName : obj.getFieldNames()) {
             Property fieldProp = model.createProperty(progNS + packagename + "." + fieldName);

--- a/frontend/src/main/java/org/abs_models/frontend/analyser/ErrorMessage.java
+++ b/frontend/src/main/java/org/abs_models/frontend/analyser/ErrorMessage.java
@@ -134,6 +134,7 @@ public enum ErrorMessage {
     WRONG_DEADLINE_TYPE("Wrong type %s in deadline annotation, should be ABS.StdLib.Duration."),
     WRONG_SIZE_ANNOTATION_TYPE("Wrong type %s in size annotation, should be a number."),
     WRONG_COST_ANNOTATION_TYPE("Wrong type %s in cost annotation, should be a number."),
+    WRONG_DOMAIN_CLASS_ANNOTATION_TYPE("Wrong type %s in domain class annotation, should evaluate to a string."),
     AMBIGIOUS_USE("The use of %s is ambigious. It can refer to the following definitions: %s."),
     WRONG_SCHEDULER_ANNOTATION_TYPE("Invalid scheduler expression, should be function invocation of type ABS.Scheduler.Process and first argument of type List<ABS.Scheduler.Process>."),
     WRONG_SCHEDULER_FUN_TYPE("Function %s invalid as scheduler function, first argument must be of type List<ABS.Scheduler.Process>, return type must be ABS.Scheduler.Process."),

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/DomainClassAnnotationChecker.java
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/DomainClassAnnotationChecker.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2009-2011, The HATS Consortium. All rights reserved. 
+ * This file is licensed under the terms of the Modified BSD License.
+ */
+package org.abs_models.frontend.typechecker.ext;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.abs_models.frontend.analyser.AnnotationHelper;
+import org.abs_models.frontend.analyser.ErrorMessage;
+import org.abs_models.frontend.analyser.TypeError;
+import org.abs_models.frontend.ast.ClassDecl;
+import org.abs_models.frontend.ast.FieldDecl;
+import org.abs_models.frontend.ast.Model;
+import org.abs_models.frontend.ast.ParamDecl;
+import org.abs_models.frontend.ast.PureExp;
+
+/// Type-check `DomainClass` annotations: must be of type String (but
+/// doesn't need to be a literal string).
+public class DomainClassAnnotationChecker extends DefaultTypeSystemExtension {
+
+    protected DomainClassAnnotationChecker(Model m) {
+        super(m);
+    }
+
+    @Override
+    public void checkClassDecl(ClassDecl decl) {
+        PureExp domainClassAnnotation = AnnotationHelper.getAnnotationValueFromName(decl.getAnnotations(), "ABS.StdLib.DomainClass");
+        if (domainClassAnnotation == null) return;
+        domainClassAnnotation.typeCheck(errors); // will complain about unknown variables
+        if (!domainClassAnnotation.getType().isStringType()) {
+            errors.add(new TypeError(domainClassAnnotation,
+                ErrorMessage.WRONG_DOMAIN_CLASS_ANNOTATION_TYPE,
+                domainClassAnnotation.getType().getQualifiedName()));
+        }
+    }
+}

--- a/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/TypeExtensionHelper.java
+++ b/frontend/src/main/java/org/abs_models/frontend/typechecker/ext/TypeExtensionHelper.java
@@ -30,6 +30,7 @@ public class TypeExtensionHelper implements TypeSystemExtension {
         register(new SchedulerChecker(m));
         register(new MainBlockChecker(m));
         register(new HttpExportChecker(m));
+        register(new DomainClassAnnotationChecker(m));
     }
 
     public TypeSystemExtension getFirstRegisteredTypeExtension(Class<?> clazz) {

--- a/frontend/src/main/resources/abs/lang/abslang.abs
+++ b/frontend/src/main/resources/abs/lang/abslang.abs
@@ -58,6 +58,7 @@ export Spec, ObjInv, Ensures, Requires, WhileInv, Resolves, Local, Role, Succeed
 export Annotation, TypeAnnotation, LocationType, Far, Near, Somewhere, Infer, NullableType, Nonnull, Nullable;
 export COG, Plain, Final, Atomic, Readonly;
 export HTTPName, HTTPCallable;
+export DomainClass;
 export Expansion, ExpansionCall;
 
 // Higher order functions
@@ -726,6 +727,11 @@ def String readln() = builtin;
 
 // Annotation for marking objects, interface methods as accessible via HTTP
 type HTTPName = String;
+
+// Annotation for semantic lifting: used for annotating class
+// definitions with an expression evaluating to an owl class of the
+// domain ontology
+type DomainClass = String;
 
 module ABS.StdLib.Exceptions;
 export *;

--- a/frontend/src/test/java/org/abs_models/backend/common/DataSourceTests.java
+++ b/frontend/src/test/java/org/abs_models/backend/common/DataSourceTests.java
@@ -57,4 +57,10 @@ public class DataSourceTests extends SemanticTests {
         assertEvalTrue(new File("abssamples/backend/DatasourceTests/sparql.abs"));
     }
 
+    @Test
+    public void domainAnnotation() throws Exception {
+        Assume.assumeTrue("Only meaningful with SPARQL support", driver.supportsSPARQL());
+        assertEvalTrue(new File("abssamples/backend/DatasourceTests/sparql_domainclasses.abs"));
+    }
+
 }

--- a/frontend/src/test/java/org/abs_models/frontend/typesystem/NegativeTypeCheckerTests.java
+++ b/frontend/src/test/java/org/abs_models/frontend/typesystem/NegativeTypeCheckerTests.java
@@ -755,4 +755,20 @@ public class NegativeTypeCheckerTests extends FrontendTest {
         // https://github.com/abstools/abstools/issues/323
         assertTypeErrors("{ foreach (string in snd(entries)) skip; }");
     }
+
+    @Test
+    public void domainAnnotationWrongType() {
+        assertTypeErrors("""
+            [DomainClass: 15]
+            class C { }
+            """);
+    }
+
+    @Test
+    public void domainAnnotationUnknownVariable() {
+        assertTypeErrors("""
+            [DomainClass: noFieldWithThisName]
+            class C { }
+            """);
+    }
 }

--- a/frontend/src/test/resources/abssamples/backend/DatasourceTests/sparql_domainclasses.abs
+++ b/frontend/src/test/resources/abssamples/backend/DatasourceTests/sparql_domainclasses.abs
@@ -1,0 +1,19 @@
+module BackendTest;
+
+[DomainClass: when i > 0 then ":containsPositive" else ":containsNonPositive"]
+class C(Int i) { }
+
+def List<Object> positives() =
+    builtin(sparql, "SELECT ?o WHERE { ?o a <:containsPositive> }" );
+
+def List<Object> non_positives() =
+    builtin(sparql, "SELECT ?o WHERE { ?o a <:containsNonPositive> }");
+
+{
+    Object o1 = new C(1);
+    Object o2 = new C(-1);
+
+    Bool testresult =
+        positives() == list[o1]
+        && non_positives() == list[o2];
+}

--- a/website/src/site/sphinx/manual/backends.rst
+++ b/website/src/site/sphinx/manual/backends.rst
@@ -35,18 +35,18 @@ ABS backends.
 
 .. table:: Backend Capabilities
 
-   =======================    ======   ======   ======
-   Feature                    Maude    Erlang   Java
-   =======================    ======   ======   ======
-   Real-Time ABS              yes      yes      yes
-   Resource Models            yes      yes      yes
-   FLI                        -        -        yes
-   SQLite queries             -        yes      yes
-   SPARQL queries             -        -        yes
-   User-defined Schedulers    yes      yes      -
-   Model API                  -        yes      yes
-   Trace record/replay        -        yes      -
-   =======================    ======   ======   ======
+   ==============================================  ======   ======   ======
+   Feature                                         Maude    Erlang   Java
+   ==============================================  ======   ======   ======
+   :ref:`Real-Time ABS <sec:timed-abs>`            yes      yes      yes
+   :ref:`Resource Models <sec:deployment>`         yes      yes      yes
+   FLI                                             -        -        yes
+   :ref:`SQLite queries <sec:sqlite>`              -        yes      yes
+   :ref:`Semantic lifting <sec:semantic-lifting>`  -        -        yes
+   User-defined Schedulers                         yes      yes      -
+   :ref:`Model API <sec:model-api>`                -        yes      yes
+   Trace record/replay                             -        yes      -
+   ==============================================  ======   ======   ======
 
 .. _sec:java-backend:
 
@@ -235,41 +235,6 @@ the generated output captured in a string:
           such filenames.  If the property is not set or contains an
           invalid value, relative filenames are resolved against the
           JVM's current directory.
-
-
-RDF Representation of Runtime State
------------------------------------
-
-The Java backend supports *semantic lifting*, i.e., obtaining a
-semantic representation of aspects of the model and the runtime state.
-The data is provided in RDF form.
-
-An ABS model can query its own state at runtime -- see
-:ref:`sparql-queries`.  The rest of this section describes how to work
-with semantically-lifted models from outside, i.e., from the command
-line or the Model API.
-
-When an ABS model is compiled with an argument ``--domain-ontology
-domain.ttl`` to the compiler, the content of the file named by that
-argument (``domain.ttl`` in the example) is added to the lifted
-program state and is visible to all SPARQL queries.  All namespaces of
-the domain ontology can be used to formulate a SPARQL query.
-
-When an ABS model is started with the ``--printRDF`` argument, this
-semantic representation is printed to the terminal in `TRTL format
-<https://www.w3.org/TR/turtle/>`__ after the model finishes.
-
-When an ABS model is started with the ``--sparqlQuery`` argument
-followed by a valid SPARQL query, that query is run after the model
-finishes, and its result is printed in TRTL form.
-
-When an ABS model is running with the :ref:`Model API <sec:model-api>`
-active, it provides a SPARQL endpoint under the ``/sparql`` URL.  The
-endpoint accepts SPARQL queries as specified in `Section 2.1
-<https://www.w3.org/TR/sparql11-protocol/#query-operation>`__ of the
-`SPARQL 1.1 Protocol <https://www.w3.org/TR/sparql11-protocol/>`__.
-The sparql endpoint returns results in `JSON format
-<https://www.w3.org/TR/sparql11-results-json/>`__ by default.
 
 
 .. _sec:erlang-backend:

--- a/website/src/site/sphinx/manual/functions.rst
+++ b/website/src/site/sphinx/manual/functions.rst
@@ -206,6 +206,8 @@ Built-in functions in the standard library include:
 - The ``random`` function
 
 
+.. _sec:sqlite:
+
 Embedded SQLite Database Queries
 ================================
 
@@ -328,108 +330,3 @@ directory is the value of the erlang function
 backend, the path to the database file is resolved relative to the
 current path of the process running the model.
 
-
-.. _sparql-queries:
-
-SPARQL Queries over Semantic State
-==================================
-
-The Java backend supports *semantic lifting*, i.e., obtaining a
-semantic representation of aspects of the model and the runtime state.
-The data is provided in RDF form.
-
-ABS models using the Java backends can use the :term:`SPARQL` query
-language to query the runtime state as an RDF triple graph.  A SPARQL
-query is defined by writing a function with a ``builtin`` body with
-two arguments: a literal ``sparql`` followed by the query as a SPARQL
-string.
-
-The result of a SPARQL query is converted into an ABS list of values.
-
-Currently only the first SPARQL variable listed in the ``SELECT``
-clause is used to construct the ABS return value.  Valid return types
-of ``builtin`` SPARQL query functions are:
-
-- ``List<Int>`` when the first SPARQL variable is a RDF literal that
-  can be converted to an integer;
-
-- ``List<Float>`` when the first SPARQL variable is a RDF literal that
-  can be converted to a float;
-
-- ``List<Rat>`` ditto;
-
-- ``List<Bool>`` when the first SPARQL variable is a RDF literal that
-  can be converted to a Boolean;
-
-- ``List<String>`` when the first SPARQL variable is a RDF literal;
-
-- ``List<I>`` when ``I`` names an interface, and the first SPARQL
-  variable is a RDF resource that names an ABS object whose class
-  implements that interface.
-
-.. note:: It is an error if the resources found by a query where ABS
-          expects objects of type ``I`` do not represent ABS objects
-          that implement ``I``, but currently such objects are
-          silently dropped when creating the result.
-
-The following namespaces are always defined:
-
-``abs:``
-   the ABS language ontology
-
-``prog:``
-   the program ontology; this ontology contains the names of all
-   classes, interfaces, members, datatypes and datatype constructors
-
-``run:``
-   the runtime ontology, containing object references
-
-Additionally, the lifted program state includes all namespace
-definitions of an included domain ontology.
-
-::
-
-  module Test;
-
-  interface I {}
-
-  class C(Int i) implements I {}
-
-  def List<String> all_integer_field_values() = builtin(sparql, ①
-      `SELECT ?i
-       WHERE { ?obj a/rdfs:label "Test.C" . ②
-               ?obj prog:Test.i ?i . }`); ③
-
-  def List<I> all_I_instances() = builtin(sparql,
-      `SELECT ?o WHERE {
-         ?o a/abs:implements/rdfs:label "BackendTest.I" . ④
-       }`);
-
-
-  {
-      I o1 = new C(5);
-      I o2 = new C(4);
-      I o3 = new C(2);
-      List<String> result = all_integer_field_values(); ⑤
-      List<I> all_I = all_I_instances(); ⑥
-  }
-
-| ① A ``builtin`` function with first argument ``sparql`` takes an
-  additional argument, a SPARQL query string.
-| ② The lifted representation of an ABS class has the ABS qualified
-  name as an ``rdfs:label`` property, so we use a property path
-  `a/rdfs:label` to find class instances.
-| ③ The ``prog:`` namespace contains, among others, all class and
-  attribute definitions.  The ``prog`` ontology uses fully qualified
-  ABS names.
-| ④ This query uses SPARQL *property paths*
-  `<https://www.w3.org/TR/sparql11-property-paths/>`__ to succinctly
-  find resources of a class that implements an interface with a label
-  ``"BackendTest.I"``.
-| ⑤ This query returns a list containing "2", "4", "5" in some
-  permutation.  Since the function returns ``List<String>``, the RDF
-  literals are converted to ABS strings.
-| ⑥ This query returns the list of all objects implementing the
-  interface ``I``.  Note that ABS objects are subject to garbage
-  collection, so otherwise unreferenced objects may or may not be
-  found by the query.

--- a/website/src/site/sphinx/manual/glossary.rst
+++ b/website/src/site/sphinx/manual/glossary.rst
@@ -5,27 +5,38 @@ Glossary
 .. glossary::
 
    ABS
+
       Used to stand for “Abstract Behavioral Syntax”; now the name of
       the ABS modeling language.
 
    COG
+
       Concurrent Object Group, the unit of concurrency in ABS.
 
    Process
    Task
+
       A task is created by an asynchronous method call and runs the
       code of the method named by the call in the context of the
       callee object.  Tasks are scheduled by the cog containing the
       callee object.  Each task has an associated future.
 
    RDF
+
       RDF is a standard model for data interchange on the Web,
       extending the linking structure of the Web to use URIs to name
       the relationship between things as well as the two ends of the
       link; see `<https://www.w3.org/RDF/>`__.
 
    SPARQL
+
       SPARQL is a set of specifications that provide languages and
       protocols to query and manipulate RDF graph content on the Web
       or in an RDF store; see
       `<https://www.w3.org/TR/sparql11-overview/>`__.
+
+   TRTL
+
+      A textual syntax for RDF that allows an RDF graph to be written
+      in a compact text form, with abbreviations for common usage
+      patterns and datatypes; see `<https://www.w3.org/TR/turtle/>`__.

--- a/website/src/site/sphinx/manual/index.rst
+++ b/website/src/site/sphinx/manual/index.rst
@@ -20,6 +20,7 @@ This section contains the language manual.
    modules
    stdlib/index
    modelapi
+   semantic-lifting
    timed
    deployment
    schedulers

--- a/website/src/site/sphinx/manual/semantic-lifting.rst
+++ b/website/src/site/sphinx/manual/semantic-lifting.rst
@@ -1,0 +1,239 @@
+.. _sec:semantic-lifting:
+
+****************
+Semantic lifting
+****************
+
+ABS implements *semantic lifting*, i.e., obtaining a semantic
+representation of aspects of the model and the runtime state.  The
+data is provided in :term:`RDF` form.
+
+Semantically-lifted program state can be queried from the command
+line, via a SPARQL endpoint implemented in the Model API, or from
+within the model itself.
+
+Semantic lifting is supported in the Java backend.
+
+
+The lifting ontology
+====================
+
+The following namespaces are always defined:
+
+``abs:``
+
+   The ABS language ontology, containing definitions for ABS
+   interfaces, classes, fields, datatypes and constructors.
+
+``prog:``
+
+   The program ontology, containing all classes, interfaces, members,
+   datatypes and datatype constructors of the model.
+
+``run:``
+
+   the runtime ontology, containing objects and object state.
+
+Additionally, when an ABS model is compiled with an argument
+``--domain-ontology domain.ttl`` to the compiler, the content of the
+file named by that argument (``domain.ttl`` in the example) is added
+to the lifted program state and is visible to all SPARQL queries.
+
+Representation of ABS language constructs
+-----------------------------------------
+
+This section shows concretely how ABS model and state information is
+lifted.
+
+.. note:: The lifting ontology might change as we gain experience
+          applying semantic lifting to concrete case studies.
+
+We consider the following small ABS model::
+
+  module Test;
+
+  interface I {}
+
+  class C (Maybe<Int> i) implements I {}
+
+  {
+    I o = new C(Just(1));
+  }
+
+All datatypes are represented as resources of type ``abs:datatype``,
+their dataconstructors are represented via ``abs:dataconstructor``::
+
+  prog:ABS.StdLib.1985362663
+        rdf:type            abs:datatype;
+        rdfs:label          "ABS.StdLib.Maybe";
+        abs:hasConstructor  prog:ABS.StdLib.Just , prog:ABS.StdLib.Nothing .
+
+  prog:ABS.StdLib.Just  rdf:type  abs:dataconstructor;
+        rdfs:label  "ABS.StdLib.Just" .
+
+All interfaces are represented as resources of type ``abs:interface``,
+with a label containing the fully-qualified name of the interface::
+
+  prog:Test.823775087  a  abs:interface;
+        rdfs:label   "Test.I";
+        abs:extends  prog:ABS.StdLib.2078396010 .  # ABS.StdLib.Object
+
+All classes are represented as resources of type ``abs:class``, again
+with a label with the class name::
+
+  prog:Test.1041552272  a  abs:class;
+        rdfs:label      "Test.C";
+        abs:hasField    prog:Test.i;
+        abs:implements  prog:Test.823775087 .
+
+  prog:Test.i  a      abs:field;
+        rdfs:label  "Test.i" .
+
+All the information above is static and calculated at compile-time.
+At runtime, the object created in the main block is lifted as
+follows::
+
+  run:obj1719860023  rdf:type prog:Test.1041552272;
+        abs:in       run:cog1652764753;
+        prog:Test.i  [ rdf:type   prog:ABS.StdLib.Just;
+                       prog:arg0  1
+                     ] .
+
+  run:cog1652764753  rdf:type  abs:cog .
+
+Numeric and string data values are represented directly, user-defined
+datatypes are lifted as anonymous resources referencing the
+constructor and its arguments.
+
+Note that the lifted representation of an object also references the
+cog that contains the object.  This information can be used to, for
+example, find all objects running on the same cog.
+
+
+
+Linking objects to domain concepts
+----------------------------------
+
+An ABS class can be linked to a domain concept via a ``DomainClass`` annotation::
+
+   [DomainClass: "domain:Housing"]
+   class House { } ①
+
+   [DomainClass: when i > 0 then ":containsPositive" else ":containsNonPositive"] ②
+   class C(Int i) { }
+
+| ① All lifted instances ``x`` of ``House`` will have an additional
+  triple ``x rdf:type domain:Housing``.
+
+| ② The ``DomainClass`` annotation is an expression that must return a
+  string and can use all fields of the object to calculate its result.
+
+
+Accessing lifted state externally
+=================================
+
+When an ABS model is started with the ``--printRDF`` argument, the
+complete semantic representation is printed to the terminal in
+:term:`TRTL` format after the model finishes.
+
+When an ABS model is started with the ``--sparqlQuery`` argument
+followed by a valid SPARQL query, that query is run after the model
+finishes and its result is printed in TRTL format.
+
+When an ABS model is running with the :ref:`Model API <sec:model-api>`
+active, it provides a SPARQL endpoint under the ``/sparql`` URL.  The
+endpoint accepts SPARQL queries as specified in `Section 2.1
+<https://www.w3.org/TR/sparql11-protocol/#query-operation>`__ of the
+`SPARQL 1.1 Protocol <https://www.w3.org/TR/sparql11-protocol/>`__.
+The sparql endpoint returns results in `JSON format
+<https://www.w3.org/TR/sparql11-results-json/>`__ by default.
+
+
+
+Accessing lifted state within the model
+=======================================
+
+A SPARQL query that can be executed at runtime from within the model
+is defined by writing a function with a ``builtin`` body with two
+arguments: a literal ``sparql`` followed by the query as a SPARQL
+string.
+
+The result of a SPARQL query is converted into an ABS list of values.
+
+Currently only the first SPARQL variable listed in the ``SELECT``
+clause is used to construct the ABS return value.  Valid return types
+of ``builtin`` SPARQL query functions are:
+
+- ``List<Int>`` when the first SPARQL variable is a RDF literal that
+  can be converted to an integer;
+
+- ``List<Float>`` when the first SPARQL variable is a RDF literal that
+  can be converted to a float;
+
+- ``List<Rat>`` ditto;
+
+- ``List<Bool>`` when the first SPARQL variable is a RDF literal that
+  can be converted to a Boolean;
+
+- ``List<String>`` when the first SPARQL variable is a RDF literal;
+
+- ``List<I>`` when ``I`` names an interface, and the first SPARQL
+  variable is a RDF resource that names an ABS object whose class
+  implements that interface.
+
+.. note:: It is an error if the resources found by a query where ABS
+          expects objects of type ``I`` do not represent ABS objects
+          that implement ``I``, but currently such objects are
+          silently dropped when creating the result.
+
+::
+
+  module Test;
+
+  interface I {}
+
+  class C(Int i) implements I {}
+
+  def List<String> all_integer_field_values() = builtin(sparql, ①
+      `SELECT ?i
+       WHERE { ?obj a/rdfs:label "Test.C" . ②
+               ?obj prog:Test.i ?i . }`); ③
+
+  def List<I> all_I_instances() = builtin(sparql,
+      `SELECT ?o WHERE {
+         ?o a/abs:implements/rdfs:label "BackendTest.I" . ④
+       }`);
+
+
+  {
+      I o1 = new C(5);
+      I o2 = new C(4);
+      I o3 = new C(2);
+      List<String> result = all_integer_field_values(); ⑤
+      List<I> all_I = all_I_instances(); ⑥
+  }
+
+| ① A ``builtin`` function with first argument ``sparql`` takes an
+  additional argument, a SPARQL query string.
+
+| ② The lifted representation of an ABS class has the ABS qualified
+  name as an ``rdfs:label`` property, so we use a property path
+  `a/rdfs:label` to find class instances.
+
+| ③ The ``prog:`` namespace contains, among others, all class and
+  attribute definitions.  The ``prog`` ontology uses fully qualified
+  ABS names.
+
+| ④ This query uses SPARQL *property paths*
+  `<https://www.w3.org/TR/sparql11-property-paths/>`__ to succinctly
+  find resources of a class that implements an interface with a label
+  ``"BackendTest.I"``.
+
+| ⑤ This query returns a list containing "2", "4", "5" in some
+  permutation.  Since the function returns ``List<String>``, the RDF
+  literals are converted to ABS strings.
+
+| ⑥ This query returns the list of all objects implementing the
+  interface ``I``.  Note that ABS objects are subject to garbage
+  collection, so objects that are not referenced may have vanished by
+  the time the query executes.


### PR DESCRIPTION
Add means for the modeler to add a triple `<object> a <domain-class>` to the lifted program state.

This is implemented via a class annotation `DomainClass` that names the domain class as an expression that returns the string.  The object's fields can be used in the expression, so the domain class can depend on the object state.