### PR TITLE
More detailed logging during unit tests

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -252,6 +252,11 @@ test {
     // Usage: ./gradlew test -Dabs.junit.erlang=0 skips (most) erlang tests
     systemProperty 'abs.junit.erlang', System.getProperty('abs.junit.erlang')
 
+    testLogging {
+        // We want to see which test case hangs, not only the class
+        events("started", "passed", "failed", "skipped")
+    }
+
     // Allow dynamic exclusion of tests (based on https://blog.jdriven.com/2017/10/run-one-or-exclude-one-test-with-gradle/)
     // Usage: gradle test -PexcludeTests='**/ErlangModelApiTests*,**/ErlangExamplesTests*'
     if (project.hasProperty('excludeTests')) {


### PR DESCRIPTION
We want to see which test hangs, not only which class it is in