### PR TITLE
Fix previous commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,9 @@
 // Make sure all subprojects use the same plugin versions; see
 // https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
 plugins {
-    id 'com.gradleup.shadow' version '9.4.2' apply false
+    // NOTE: do not update to version 9 without checking that compiling and
+    // running a Java model works
+    id 'com.gradleup.shadow' version '8.3.9' apply false
     // ./gradlew dependencyUpdates to check for library updates
     id "com.github.ben-manes.versions" version "0.54.0"
 }


### PR DESCRIPTION
Version 9 of the shadow plugin creates an invalid absfrontend.jar file; revert to 8.3.9 until we find a proper fix.